### PR TITLE
Add dark mode toggle with moon icon

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,16 @@
 import PanelGrid from "./components/PanelGrid";
 import BackButton from "./components/BackButton";
+import DarkModeToggle from "./components/DarkModeToggle";
 
 export default function App() {
   return (
-    <div className="relative w-screen h-screen border-4 border-sepia-smoke">
+    <div
+      className="relative w-screen h-screen border-4"
+      style={{ borderColor: "var(--border)" }}
+    >
       <PanelGrid />
       <BackButton />
+      <DarkModeToggle />
     </div>
   );
 }

--- a/src/components/DarkModeToggle.jsx
+++ b/src/components/DarkModeToggle.jsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+export default function DarkModeToggle() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDark) {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [isDark]);
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle dark mode"
+      className="absolute top-4 right-4 p-2 rounded-full"
+      onClick={() => setIsDark(!isDark)}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="w-6 h-6 transition-colors"
+        style={{ color: isDark ? "var(--accent)" : "var(--muted)" }}
+      >
+        <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -1,6 +1,9 @@
 export default function PanelCard({ className = "", children }) {
   return (
-    <div className={`w-full h-full border-4 border-sepia-smoke ${className}`}>
+    <div
+      className={`w-full h-full border-4 ${className}`}
+      style={{ borderColor: "var(--border)" }}
+    >
       {children}
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,24 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Theme color variables */
+:root {
+  --background: #ffffff;
+  --foreground: #1e293b;
+  --accent: #2563eb;
+  --muted: #94a3b8;
+  --border: #e2e8f0;
+}
+
+.dark {
+  --background: #0d1117;
+  --foreground: #f1f5f9;
+  --accent: #3b82f6;
+  --muted: #64748b;
+  --border: #1e293b;
+}
+
 body {
-  @apply bg-coal-black text-soft-bone;
+  background-color: var(--background);
+  color: var(--foreground);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 import forms from "@tailwindcss/forms";
 
 export default {
+  darkMode: "class",
   content: ["./public/index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- define light and dark theme variables and enable class-based dark mode
- add a moon toggle button that switches themes and highlights when dark mode is active
- use theme border color on panels for consistency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f3a35160883219e8312441c2671c3