### PR TITLE
Add comic-style grid with interactive panel cards

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -1,10 +1,27 @@
-export default function PanelCard({ className = "", children }) {
+export default function PanelCard({
+  className = "",
+  imageSrc,
+  label,
+  onClick,
+}) {
   return (
     <div
-      className={`w-full h-full border-4 ${className}`}
+      className={`relative w-full h-full border-4 overflow-hidden ${className}`}
       style={{ borderColor: "var(--border)" }}
+      onClick={onClick}
     >
-      {children}
+      {imageSrc && (
+        <img
+          src={imageSrc}
+          alt={label}
+          className="object-cover w-full h-full"
+        />
+      )}
+      {label && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          {label}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,21 +1,43 @@
 import PanelCard from "./PanelCard";
-import PanelContent from "./PanelContent";
-
 export default function PanelGrid() {
   return (
-    <div className="grid grid-cols-2 grid-rows-2 w-full h-full">
-      <PanelCard className="bg-faded-rust">
-        <PanelContent>Panel 1</PanelContent>
-      </PanelCard>
-      <PanelCard className="bg-sepia-smoke">
-        <PanelContent>Panel 2</PanelContent>
-      </PanelCard>
-      <PanelCard className="bg-midnight-teal">
-        <PanelContent>Panel 3</PanelContent>
-      </PanelCard>
-      <PanelCard className="bg-aged-brass text-coal-black">
-        <PanelContent>Panel 4</PanelContent>
-      </PanelCard>
+    <div className="grid grid-cols-2 grid-rows-3 gap-2 w-full h-full">
+      <PanelCard
+        className="bg-faded-rust col-span-2"
+        imageSrc="https://via.placeholder.com/300x150?text=Panel+1"
+        label="Panel 1"
+        onClick={() => {}}
+      />
+      <PanelCard
+        className="bg-sepia-smoke"
+        imageSrc="https://via.placeholder.com/150?text=Panel+2"
+        label="Panel 2"
+        onClick={() => {}}
+      />
+      <PanelCard
+        className="bg-midnight-teal row-span-2"
+        imageSrc="https://via.placeholder.com/150?text=Panel+3"
+        label="Panel 3"
+        onClick={() => {}}
+      />
+      <PanelCard
+        className="bg-aged-brass text-coal-black"
+        imageSrc="https://via.placeholder.com/150?text=Panel+4"
+        label="Panel 4"
+        onClick={() => {}}
+      />
+      <PanelCard
+        className="bg-faded-rust col-span-2"
+        imageSrc="https://via.placeholder.com/300x150?text=Panel+5"
+        label="Panel 5"
+        onClick={() => {}}
+      />
+      <PanelCard
+        className="bg-sepia-smoke"
+        imageSrc="https://via.placeholder.com/150?text=Panel+6"
+        label="Panel 6"
+        onClick={() => {}}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Expand `PanelGrid` to a 2x3 grid with six panels in a comic-style layout.
- Enhance `PanelCard` to accept image, label and click handler props for richer placeholders.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*


------
https://chatgpt.com/codex/tasks/task_e_689f43d5026c8321befea525ec3f8c23