### PR TITLE
feat: add image-based PanelCard component

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -1,10 +1,26 @@
-export default function PanelCard({ className = "", children }) {
+export default function PanelCard({
+  imageSrc,
+  label,
+  onClick,
+  className = "",
+}) {
   return (
     <div
-      className={`w-full h-full border-4 ${className}`}
+      onClick={onClick}
+      className={`relative group cursor-pointer w-full h-full overflow-hidden border-4 ${className}`}
       style={{ borderColor: "var(--border)" }}
     >
-      {children}
+      {imageSrc && (
+        <img
+          src={imageSrc}
+          alt={label}
+          className="w-full h-full object-cover transition duration-300 group-hover:scale-105"
+        />
+      )}
+      <div className="absolute inset-0 bg-black/40 group-hover:bg-black/20 transition" />
+      {label && (
+        <span className="absolute bottom-2 left-2 z-10 text-white">{label}</span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- make PanelCard accept `imageSrc`, `label`, and `onClick`
- render image with dark overlay and label positioning
- add hover scale animation for interactive cards

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_689f43d8d5488321ad9e4d81d63df19d