### PR TITLE
Improve panel responsiveness for narrow viewports

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -6,7 +6,7 @@ export default function PanelCard({
 }) {
   return (
     <div
-      className={`relative w-full h-full border-4 overflow-hidden ${className}`}
+      className={`relative w-full border-4 overflow-hidden aspect-[3/2] ${className}`}
       style={{ borderColor: "var(--border)" }}
       onClick={onClick}
     >

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,7 +1,7 @@
 import PanelCard from "./PanelCard";
 export default function PanelGrid() {
   return (
-    <div className="grid grid-cols-2 grid-rows-3 gap-2 w-full h-full">
+    <div className="grid grid-cols-2 grid-rows-3 gap-2 w-full h-full sm:grid-cols-1 sm:grid-rows-6">
       <PanelCard
         className="bg-faded-rust col-span-2"
         imageSrc="https://via.placeholder.com/300x150?text=Panel+1"


### PR DESCRIPTION
## Summary
- stack panels vertically on small screens
- enforce consistent card aspect ratio for narrow viewports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_689f4a90df0883219dcfee01bd5c2350