### PR TITLE
Refine panel grid layout and styling

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -8,8 +8,7 @@ export default function PanelCard({
 }) {
   return (
     <div
-      className={`relative w-full border-4 overflow-hidden aspect-[3/2] ${className}`}
-      style={{ borderColor: "var(--border)" }}
+      className={`relative w-full overflow-hidden aspect-[3/2] ${className}`}
       onClick={onClick}
     >
       {imageSrc && (

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,10 +1,11 @@
 import PanelCard from "./PanelCard";
+
 export default function PanelGrid() {
   return (
-    <div className="grid grid-cols-2 grid-rows-3 gap-2 w-full h-full sm:grid-cols-1 sm:grid-rows-6">
+    <div className="grid grid-cols-6 grid-rows-3 gap-2 w-full h-full sm:grid-cols-1 sm:grid-rows-5">
       <PanelCard
-        className="bg-faded-rust col-span-2"
-        imageSrc="https://via.placeholder.com/300x150?text=Panel+1"
+        className="bg-blue-900 col-span-6 sm:col-span-1"
+        imageSrc="https://via.placeholder.com/600x300?text=Panel+1"
         label="Panel 1"
         onClick={() => {
           console.log("Panel 1 clicked");
@@ -12,8 +13,8 @@ export default function PanelGrid() {
         }}
       />
       <PanelCard
-        className="bg-sepia-smoke"
-        imageSrc="https://via.placeholder.com/150?text=Panel+2"
+        className="bg-blue-700 col-span-3 sm:col-span-1"
+        imageSrc="https://via.placeholder.com/300x200?text=Panel+2"
         label="Panel 2"
         onClick={() => {
           console.log("Panel 2 clicked");
@@ -21,8 +22,8 @@ export default function PanelGrid() {
         }}
       />
       <PanelCard
-        className="bg-midnight-teal row-span-2"
-        imageSrc="https://via.placeholder.com/150?text=Panel+3"
+        className="bg-blue-600 col-span-3 sm:col-span-1"
+        imageSrc="https://via.placeholder.com/300x200?text=Panel+3"
         label="Panel 3"
         onClick={() => {
           console.log("Panel 3 clicked");
@@ -30,8 +31,8 @@ export default function PanelGrid() {
         }}
       />
       <PanelCard
-        className="bg-aged-brass text-coal-black"
-        imageSrc="https://via.placeholder.com/150?text=Panel+4"
+        className="bg-blue-500 col-span-2 sm:col-span-1"
+        imageSrc="https://via.placeholder.com/200x133?text=Panel+4"
         label="Panel 4"
         onClick={() => {
           console.log("Panel 4 clicked");
@@ -39,21 +40,12 @@ export default function PanelGrid() {
         }}
       />
       <PanelCard
-        className="bg-faded-rust col-span-2"
-        imageSrc="https://via.placeholder.com/300x150?text=Panel+5"
+        className="bg-blue-400 col-span-4 sm:col-span-1"
+        imageSrc="https://via.placeholder.com/400x267?text=Panel+5"
         label="Panel 5"
         onClick={() => {
           console.log("Panel 5 clicked");
           // TODO: Route to Panel 5 subpage
-        }}
-      />
-      <PanelCard
-        className="bg-sepia-smoke"
-        imageSrc="https://via.placeholder.com/150?text=Panel+6"
-        label="Panel 6"
-        onClick={() => {
-          console.log("Panel 6 clicked");
-          // TODO: Route to Panel 6 subpage
         }}
       />
     </div>


### PR DESCRIPTION
## Summary
- Remove panel borders for a cleaner appearance
- Rework panel grid to three-row layout with 1-2-2 panel distribution and blue-themed styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f4e523cd083219ae9a8a99139ce82