### PR TITLE
Refine panel grid layout and styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import DarkModeToggle from "./components/DarkModeToggle";
 export default function App() {
   return (
     <div
-      className="relative w-screen h-screen border-4"
+      className="relative w-screen h-screen overflow-hidden border-4"
       style={{ borderColor: "var(--border)" }}
     >
       <PanelGrid />

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -8,8 +8,7 @@ export default function PanelCard({
 }) {
   return (
     <div
-      className={`relative w-full border-4 overflow-hidden aspect-[3/2] ${className}`}
-      style={{ borderColor: "var(--border)" }}
+      className={`relative w-full h-full overflow-hidden ${className}`}
       onClick={onClick}
     >
       {imageSrc && (

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,61 +1,59 @@
 import PanelCard from "./PanelCard";
+
 export default function PanelGrid() {
   return (
-    <div className="grid grid-cols-2 grid-rows-3 gap-2 w-full h-full sm:grid-cols-1 sm:grid-rows-6">
-      <PanelCard
-        className="bg-faded-rust col-span-2"
-        imageSrc="https://via.placeholder.com/300x150?text=Panel+1"
-        label="Panel 1"
-        onClick={() => {
-          console.log("Panel 1 clicked");
-          // TODO: Route to Panel 1 subpage
-        }}
-      />
-      <PanelCard
-        className="bg-sepia-smoke"
-        imageSrc="https://via.placeholder.com/150?text=Panel+2"
-        label="Panel 2"
-        onClick={() => {
-          console.log("Panel 2 clicked");
-          // TODO: Route to Panel 2 subpage
-        }}
-      />
-      <PanelCard
-        className="bg-midnight-teal row-span-2"
-        imageSrc="https://via.placeholder.com/150?text=Panel+3"
-        label="Panel 3"
-        onClick={() => {
-          console.log("Panel 3 clicked");
-          // TODO: Route to Panel 3 subpage
-        }}
-      />
-      <PanelCard
-        className="bg-aged-brass text-coal-black"
-        imageSrc="https://via.placeholder.com/150?text=Panel+4"
-        label="Panel 4"
-        onClick={() => {
-          console.log("Panel 4 clicked");
-          // TODO: Route to Panel 4 subpage
-        }}
-      />
-      <PanelCard
-        className="bg-faded-rust col-span-2"
-        imageSrc="https://via.placeholder.com/300x150?text=Panel+5"
-        label="Panel 5"
-        onClick={() => {
-          console.log("Panel 5 clicked");
-          // TODO: Route to Panel 5 subpage
-        }}
-      />
-      <PanelCard
-        className="bg-sepia-smoke"
-        imageSrc="https://via.placeholder.com/150?text=Panel+6"
-        label="Panel 6"
-        onClick={() => {
-          console.log("Panel 6 clicked");
-          // TODO: Route to Panel 6 subpage
-        }}
-      />
+    <div className="grid grid-rows-3 gap-4 w-full h-full">
+      <div className="grid h-full grid-cols-1 gap-4">
+        <PanelCard
+          className="bg-blue-900 h-full"
+          imageSrc="https://via.placeholder.com/600x300?text=Panel+1"
+          label="Panel 1"
+          onClick={() => {
+            console.log("Panel 1 clicked");
+            // TODO: Route to Panel 1 subpage
+          }}
+        />
+      </div>
+      <div className="grid h-full grid-cols-2 gap-4 sm:grid-cols-1">
+        <PanelCard
+          className="bg-blue-700 h-full"
+          imageSrc="https://via.placeholder.com/300x200?text=Panel+2"
+          label="Panel 2"
+          onClick={() => {
+            console.log("Panel 2 clicked");
+            // TODO: Route to Panel 2 subpage
+          }}
+        />
+        <PanelCard
+          className="bg-blue-600 h-full"
+          imageSrc="https://via.placeholder.com/300x200?text=Panel+3"
+          label="Panel 3"
+          onClick={() => {
+            console.log("Panel 3 clicked");
+            // TODO: Route to Panel 3 subpage
+          }}
+        />
+      </div>
+      <div className="grid h-full grid-cols-3 gap-4 sm:grid-cols-1">
+        <PanelCard
+          className="bg-blue-500 h-full col-span-1 sm:col-span-1"
+          imageSrc="https://via.placeholder.com/200x133?text=Panel+4"
+          label="Panel 4"
+          onClick={() => {
+            console.log("Panel 4 clicked");
+            // TODO: Route to Panel 4 subpage
+          }}
+        />
+        <PanelCard
+          className="bg-blue-400 h-full col-span-2 sm:col-span-1"
+          imageSrc="https://via.placeholder.com/400x267?text=Panel+5"
+          label="Panel 5"
+          onClick={() => {
+            console.log("Panel 5 clicked");
+            // TODO: Route to Panel 5 subpage
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -22,4 +22,5 @@
 body {
   background-color: var(--background);
   color: var(--foreground);
+  overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- Make panel grid a 3-row layout that fills the viewport and keeps panels proportionally sized
- Prevent scrolling by hiding overflow on the page and panel container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f4e523cd083219ae9a8a99139ce82