### PR TITLE
Fix panel spacing and responsive layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import DarkModeToggle from "./components/DarkModeToggle";
 export default function App() {
   return (
     <div
-      className="relative w-screen h-screen overflow-hidden border-4"
+      className="relative w-screen h-screen overflow-hidden border-4 p-4"
       style={{ borderColor: "var(--border)" }}
     >
       <PanelGrid />

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -14,7 +14,7 @@ export default function PanelGrid() {
           }}
         />
       </div>
-      <div className="grid h-full grid-cols-2 gap-4 sm:grid-cols-1">
+      <div className="grid h-full grid-cols-1 gap-4 sm:grid-cols-2">
         <PanelCard
           className="bg-blue-700 h-full"
           imageSrc="https://via.placeholder.com/300x200?text=Panel+2"
@@ -34,7 +34,7 @@ export default function PanelGrid() {
           }}
         />
       </div>
-      <div className="grid h-full grid-cols-3 gap-4 sm:grid-cols-1">
+      <div className="grid h-full grid-cols-1 gap-4 sm:grid-cols-3">
         <PanelCard
           className="bg-blue-500 h-full col-span-1 sm:col-span-1"
           imageSrc="https://via.placeholder.com/200x133?text=Panel+4"
@@ -45,7 +45,7 @@ export default function PanelGrid() {
           }}
         />
         <PanelCard
-          className="bg-blue-400 h-full col-span-2 sm:col-span-1"
+          className="bg-blue-400 h-full col-span-1 sm:col-span-2"
           imageSrc="https://via.placeholder.com/400x267?text=Panel+5"
           label="Panel 5"
           onClick={() => {


### PR DESCRIPTION
## Summary
- Add padding so page margin matches panel gaps
- Correct responsive grid classes so panels keep comic-style layout on wider screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_689f56a2c8548321be1e852933ec289c