### PR TITLE
Add button border and panel hover animation

### DIFF
--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -6,9 +6,10 @@ export default function BackButton() {
   return (
     <button
       type="button"
-      className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-12 h-12 rounded-full text-soft-bone transition-colors duration-200 ${
+      className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-12 h-12 rounded-full text-soft-bone border-[1rem] transition-colors duration-200 ${
         hovered ? "bg-faded-rust/80" : "bg-faded-rust"
       }`}
+      style={{ borderColor: "var(--border)" }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -8,7 +8,7 @@ export default function PanelCard({
 }) {
   return (
     <div
-      className={`relative w-full h-full overflow-hidden ${className}`}
+      className={`relative w-full h-full overflow-hidden cursor-pointer transition-transform duration-300 hover:scale-105 ${className}`}
       onClick={onClick}
     >
       {imageSrc && (


### PR DESCRIPTION
## Summary
- add thick border to the centered base button matching panel spacing
- animate panels with a simple scale effect on hover

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_689f59c65f008321a201c86ca5a9d35e