### PR TITLE
Add React Router navigation with lazy-loaded routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "framer-motion": "^11.0.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.7",
@@ -969,6 +970,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4589,6 +4599,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "framer-motion": "^11.0.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,14 @@
-import PanelGrid from "./components/PanelGrid";
+import { Suspense, lazy } from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
 import BackButton from "./components/BackButton";
 import DarkModeToggle from "./components/DarkModeToggle";
+
+const PanelGrid = lazy(() => import("./components/PanelGrid"));
+const Read = lazy(() => import("./pages/Read"));
+const Buy = lazy(() => import("./pages/Buy"));
+const World = lazy(() => import("./pages/World"));
+const Team = lazy(() => import("./pages/Team"));
+const Contact = lazy(() => import("./pages/Contact"));
 
 export default function App() {
   return (
@@ -8,7 +16,17 @@ export default function App() {
       className="relative w-screen h-screen overflow-hidden border-4 p-4"
       style={{ borderColor: "var(--border)" }}
     >
-      <PanelGrid />
+      <Suspense fallback={<div>Loading...</div>}>
+        <Routes>
+          <Route path="/" element={<PanelGrid />} />
+          <Route path="/read" element={<Read />} />
+          <Route path="/buy" element={<Buy />} />
+          <Route path="/world" element={<World />} />
+          <Route path="/team" element={<Team />} />
+          <Route path="/contact" element={<Contact />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </Suspense>
       <BackButton />
       <DarkModeToggle />
     </div>

--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 export default function BackButton() {
   const [hovered, setHovered] = useState(false);
+  const navigate = useNavigate();
 
   return (
     <button
@@ -12,6 +14,7 @@ export default function BackButton() {
       style={{ borderColor: "var(--border)" }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      onClick={() => navigate(-1)}
     >
       Base
     </button>

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -1,15 +1,14 @@
+import { Link } from "react-router-dom";
+
 export default function PanelCard({
   className = "",
   imageSrc,
   label,
-  // Handler for when the panel is clicked.
-  // TODO: Wire this up to navigation once routing is added.
-  onClick,
+  to,
 }) {
-  return (
+  const content = (
     <div
       className={`relative w-full h-full overflow-hidden cursor-pointer transition-transform duration-300 hover:scale-105 ${className}`}
-      onClick={onClick}
     >
       {imageSrc && (
         <img
@@ -24,5 +23,13 @@ export default function PanelCard({
         </div>
       )}
     </div>
+  );
+
+  return to ? (
+    <Link to={to} className="block h-full">
+      {content}
+    </Link>
+  ) : (
+    content
   );
 }

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -6,52 +6,37 @@ export default function PanelGrid() {
       <div className="grid h-full grid-cols-1 gap-4">
         <PanelCard
           className="bg-blue-900 h-full"
-          imageSrc="https://via.placeholder.com/600x300?text=Panel+1"
-          label="Panel 1"
-          onClick={() => {
-            console.log("Panel 1 clicked");
-            // TODO: Route to Panel 1 subpage
-          }}
+          imageSrc="https://via.placeholder.com/600x300?text=Read"
+          label="READ"
+          to="/read"
         />
       </div>
       <div className="grid h-full grid-cols-2 gap-4">
         <PanelCard
           className="bg-blue-700 h-full"
-          imageSrc="https://via.placeholder.com/300x200?text=Panel+2"
-          label="Panel 2"
-          onClick={() => {
-            console.log("Panel 2 clicked");
-            // TODO: Route to Panel 2 subpage
-          }}
+          imageSrc="https://via.placeholder.com/300x200?text=Buy"
+          label="BUY"
+          to="/buy"
         />
         <PanelCard
           className="bg-blue-600 h-full"
-          imageSrc="https://via.placeholder.com/300x200?text=Panel+3"
-          label="Panel 3"
-          onClick={() => {
-            console.log("Panel 3 clicked");
-            // TODO: Route to Panel 3 subpage
-          }}
+          imageSrc="https://via.placeholder.com/300x200?text=World"
+          label="WORLD"
+          to="/world"
         />
       </div>
       <div className="grid h-full grid-cols-3 gap-4">
         <PanelCard
           className="bg-blue-500 h-full col-span-1"
-          imageSrc="https://via.placeholder.com/200x133?text=Panel+4"
-          label="Panel 4"
-          onClick={() => {
-            console.log("Panel 4 clicked");
-            // TODO: Route to Panel 4 subpage
-          }}
+          imageSrc="https://via.placeholder.com/200x133?text=Team"
+          label="TEAM"
+          to="/team"
         />
         <PanelCard
           className="bg-blue-400 h-full col-span-2"
-          imageSrc="https://via.placeholder.com/400x267?text=Panel+5"
-          label="Panel 5"
-          onClick={() => {
-            console.log("Panel 5 clicked");
-            // TODO: Route to Panel 5 subpage
-          }}
+          imageSrc="https://via.placeholder.com/400x267?text=Contact"
+          label="CONTACT"
+          to="/contact"
         />
       </div>
     </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,0 +1,5 @@
+import PanelContent from "../components/PanelContent";
+
+export default function Buy() {
+  return <PanelContent>Buy Page</PanelContent>;
+}

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,0 +1,5 @@
+import PanelContent from "../components/PanelContent";
+
+export default function Contact() {
+  return <PanelContent>Contact Page</PanelContent>;
+}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,0 +1,5 @@
+import PanelContent from "../components/PanelContent";
+
+export default function Read() {
+  return <PanelContent>Read Page</PanelContent>;
+}

--- a/src/pages/Team.jsx
+++ b/src/pages/Team.jsx
@@ -1,0 +1,5 @@
+import PanelContent from "../components/PanelContent";
+
+export default function Team() {
+  return <PanelContent>Team Page</PanelContent>;
+}

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -1,0 +1,5 @@
+import PanelContent from "../components/PanelContent";
+
+export default function World() {
+  return <PanelContent>World Page</PanelContent>;
+}


### PR DESCRIPTION
## Summary
- Add react-router-dom and wrap app in BrowserRouter
- Implement lazy-loaded routes for Read, Buy, World, Team, and Contact pages with fallback to home
- Wire panel grid and back button to use new routing

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f65e6241083219373a9c988c79a2d