### PR TITLE
Set panel cards to white background

### DIFF
--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -5,7 +5,7 @@ export default function PanelGrid() {
     <div className="grid grid-rows-3 gap-4 w-full h-full">
       <div className="grid h-full grid-cols-1 gap-4">
         <PanelCard
-          className="bg-blue-900 h-full"
+          className="bg-white h-full"
           imageSrc="https://via.placeholder.com/600x300?text=Read"
           label="READ"
           to="/read"
@@ -13,13 +13,13 @@ export default function PanelGrid() {
       </div>
       <div className="grid h-full grid-cols-2 gap-4">
         <PanelCard
-          className="bg-blue-700 h-full"
+          className="bg-white h-full"
           imageSrc="https://via.placeholder.com/300x200?text=Buy"
           label="BUY"
           to="/buy"
         />
         <PanelCard
-          className="bg-blue-600 h-full"
+          className="bg-white h-full"
           imageSrc="https://via.placeholder.com/300x200?text=World"
           label="WORLD"
           to="/world"
@@ -27,13 +27,13 @@ export default function PanelGrid() {
       </div>
       <div className="grid h-full grid-cols-3 gap-4">
         <PanelCard
-          className="bg-blue-500 h-full col-span-1"
+          className="bg-white h-full col-span-1"
           imageSrc="https://via.placeholder.com/200x133?text=Team"
           label="TEAM"
           to="/team"
         />
         <PanelCard
-          className="bg-blue-400 h-full col-span-2"
+          className="bg-white h-full col-span-2"
           imageSrc="https://via.placeholder.com/400x267?text=Contact"
           label="CONTACT"
           to="/contact"


### PR DESCRIPTION
## Summary
- Replace per-panel blue backgrounds with `bg-white` so every panel card has a consistent white background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_689f7071fe308321a9b7e4f9c7264191