### PR TITLE
style panel labels on panel cards

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -19,7 +19,9 @@ export default function PanelCard({
       )}
       {label && (
         <div className="absolute inset-0 flex items-center justify-center">
-          {label}
+          <span className="text-black font-bold uppercase text-center">
+            {label}
+          </span>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- wrap panel card labels in a styled span for better readability

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_689f7073c9ec8321aa9d8f4939edff11