### PR TITLE
Fix PanelGrid row three layout

### DIFF
--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -27,13 +27,13 @@ export default function PanelGrid() {
       </div>
       <div className="grid h-full grid-cols-3 gap-4">
         <PanelCard
-          className="bg-blue-500 h-full col-span-1"
+          className="bg-blue-500 h-full col-span-2"
           imageSrc="https://via.placeholder.com/200x133?text=Team"
           label="TEAM"
           to="/team"
         />
         <PanelCard
-          className="bg-blue-400 h-full col-span-2"
+          className="bg-blue-400 h-full col-span-1"
           imageSrc="https://via.placeholder.com/400x267?text=Contact"
           label="CONTACT"
           to="/contact"


### PR DESCRIPTION
## Summary
- Swap panel widths in PanelGrid third row so first panel spans two columns and second spans one.

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*
- `npm run dev` & `curl -I http://localhost:5174/` *(404 Not Found; index.html missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f707866848321aa2fac155044f38d