### PR TITLE
Remove scale animation for panel hover and add dark overlay

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -8,7 +8,7 @@ export default function PanelCard({
 }) {
   const content = (
     <div
-      className={`relative w-full h-full overflow-hidden cursor-pointer transition-transform duration-300 hover:scale-105 ${className}`}
+      className={`relative w-full h-full overflow-hidden cursor-pointer group ${className}`}
     >
       {imageSrc && (
         <img
@@ -17,8 +17,9 @@ export default function PanelCard({
           className="object-cover w-full h-full"
         />
       )}
+      <div className="absolute inset-0 bg-black opacity-0 transition-opacity duration-300 group-hover:opacity-20 pointer-events-none" />
       {label && (
-        <div className="absolute inset-0 flex items-center justify-center">
+        <div className="absolute inset-0 flex items-center justify-center z-10">
           {label}
         </div>
       )}


### PR DESCRIPTION
## Summary
- eliminate hover scale transform from `PanelCard`
- add subtle dark overlay on hover for cleaner effect

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f70ab1a388321ac8269f9a9d00350