### PR TITLE
Animate panel labels across navigation

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
 
 export default function PanelCard({
   className = "",
@@ -20,9 +21,12 @@ export default function PanelCard({
       <div className="absolute inset-0 bg-black opacity-0 transition-opacity duration-300 group-hover:opacity-20 pointer-events-none" />
       {label && (
         <div className="absolute inset-0 flex items-center justify-center">
-          <span className="text-black font-bold uppercase text-center">
+          <motion.span
+            layoutId={label}
+            className="text-black font-bold uppercase text-center"
+          >
             {label}
-          </span>
+          </motion.span>
         </div>
       )}
     </div>

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,5 +1,15 @@
 import PanelContent from "../components/PanelContent";
+import { motion } from "framer-motion";
 
 export default function Buy() {
-  return <PanelContent>Buy Page</PanelContent>;
+  return (
+    <PanelContent>
+      <motion.h1
+        layoutId="BUY"
+        className="text-4xl font-bold uppercase"
+      >
+        BUY
+      </motion.h1>
+    </PanelContent>
+  );
 }

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,5 +1,15 @@
 import PanelContent from "../components/PanelContent";
+import { motion } from "framer-motion";
 
 export default function Contact() {
-  return <PanelContent>Contact Page</PanelContent>;
+  return (
+    <PanelContent>
+      <motion.h1
+        layoutId="CONTACT"
+        className="text-4xl font-bold uppercase"
+      >
+        CONTACT
+      </motion.h1>
+    </PanelContent>
+  );
 }

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,5 +1,15 @@
 import PanelContent from "../components/PanelContent";
+import { motion } from "framer-motion";
 
 export default function Read() {
-  return <PanelContent>Read Page</PanelContent>;
+  return (
+    <PanelContent>
+      <motion.h1
+        layoutId="READ"
+        className="text-4xl font-bold uppercase"
+      >
+        READ
+      </motion.h1>
+    </PanelContent>
+  );
 }

--- a/src/pages/Team.jsx
+++ b/src/pages/Team.jsx
@@ -1,5 +1,15 @@
 import PanelContent from "../components/PanelContent";
+import { motion } from "framer-motion";
 
 export default function Team() {
-  return <PanelContent>Team Page</PanelContent>;
+  return (
+    <PanelContent>
+      <motion.h1
+        layoutId="TEAM"
+        className="text-4xl font-bold uppercase"
+      >
+        TEAM
+      </motion.h1>
+    </PanelContent>
+  );
 }

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -1,5 +1,15 @@
 import PanelContent from "../components/PanelContent";
+import { motion } from "framer-motion";
 
 export default function World() {
-  return <PanelContent>World Page</PanelContent>;
+  return (
+    <PanelContent>
+      <motion.h1
+        layoutId="WORLD"
+        className="text-4xl font-bold uppercase"
+      >
+        WORLD
+      </motion.h1>
+    </PanelContent>
+  );
 }


### PR DESCRIPTION
## Summary
- Animate panel labels using Framer Motion by sharing layout IDs between cards and pages
- Render matching `motion.h1` elements on subpages with styling for smooth transitions

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f755f204c832189ca575235c3d83e