### PR TITLE
feat: add layout animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy } from "react";
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
+import { AnimatePresence, LayoutGroup } from "framer-motion";
 import BackButton from "./components/BackButton";
 import DarkModeToggle from "./components/DarkModeToggle";
 
@@ -11,24 +12,30 @@ const Team = lazy(() => import("./pages/Team"));
 const Contact = lazy(() => import("./pages/Contact"));
 
 export default function App() {
+  const location = useLocation();
+
   return (
-    <div
-      className="relative w-screen h-screen overflow-hidden border-4 p-4"
-      style={{ borderColor: "var(--border)" }}
-    >
-      <Suspense fallback={<div>Loading...</div>}>
-        <Routes>
-          <Route path="/" element={<PanelGrid />} />
-          <Route path="/read" element={<Read />} />
-          <Route path="/buy" element={<Buy />} />
-          <Route path="/world" element={<World />} />
-          <Route path="/team" element={<Team />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </Suspense>
-      <BackButton />
-      <DarkModeToggle />
-    </div>
+    <LayoutGroup>
+      <div
+        className="relative w-screen h-screen overflow-hidden border-4 p-4"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <Suspense fallback={<div>Loading...</div>}>
+          <AnimatePresence mode="wait">
+            <Routes location={location} key={location.pathname}>
+              <Route path="/" element={<PanelGrid />} />
+              <Route path="/read" element={<Read />} />
+              <Route path="/buy" element={<Buy />} />
+              <Route path="/world" element={<World />} />
+              <Route path="/team" element={<Team />} />
+              <Route path="/contact" element={<Contact />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </AnimatePresence>
+        </Suspense>
+        <BackButton />
+        <DarkModeToggle />
+      </div>
+    </LayoutGroup>
   );
 }


### PR DESCRIPTION
## Summary
- wrap routes in motion components for page transitions
- persist layout ids across pages with LayoutGroup

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_689f755f0b608321b7776bc36d016eb6