### PR TITLE
Animate back button with layout transitions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
+import { LayoutGroup } from "framer-motion";
 import BackButton from "./components/BackButton";
 import DarkModeToggle from "./components/DarkModeToggle";
 
@@ -16,19 +17,21 @@ export default function App() {
       className="relative w-screen h-screen overflow-hidden border-4 p-4"
       style={{ borderColor: "var(--border)" }}
     >
-      <Suspense fallback={<div>Loading...</div>}>
-        <Routes>
-          <Route path="/" element={<PanelGrid />} />
-          <Route path="/read" element={<Read />} />
-          <Route path="/buy" element={<Buy />} />
-          <Route path="/world" element={<World />} />
-          <Route path="/team" element={<Team />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </Suspense>
-      <BackButton />
-      <DarkModeToggle />
+      <LayoutGroup>
+        <Suspense fallback={<div>Loading...</div>}>
+          <Routes>
+            <Route path="/" element={<PanelGrid />} />
+            <Route path="/read" element={<Read />} />
+            <Route path="/buy" element={<Buy />} />
+            <Route path="/world" element={<World />} />
+            <Route path="/team" element={<Team />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Suspense>
+        <BackButton />
+        <DarkModeToggle />
+      </LayoutGroup>
     </div>
   );
 }

--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -1,22 +1,35 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
+import { motion } from "framer-motion";
 
 export default function BackButton() {
   const [hovered, setHovered] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
+  const isHome = location.pathname === "/";
+
+  const positionClasses = isHome
+    ? "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+    : "left-4 top-4";
+  const bgClass = hovered ? "bg-faded-rust/80" : "bg-faded-rust";
+  const baseClasses =
+    "absolute w-12 h-12 rounded-full text-soft-bone border-[1rem] transition-colors duration-200";
+  const className = `${baseClasses} ${positionClasses} ${bgClass}`;
 
   return (
-    <button
+    <motion.button
+      layoutId="back-button"
       type="button"
-      className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-12 h-12 rounded-full text-soft-bone border-[1rem] transition-colors duration-200 ${
-        hovered ? "bg-faded-rust/80" : "bg-faded-rust"
-      }`}
+      className={className}
       style={{ borderColor: "var(--border)" }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onClick={() => navigate(-1)}
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.9 }}
     >
       Base
-    </button>
+    </motion.button>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap BackButton in framer-motion's `motion.button` with shared `layoutId`
- Position BackButton via `useLocation` to move from centered home placement to top-left on subpages
- Keep BackButton within a `LayoutGroup` for consistent layout animations across routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f755ffd84832188ee2123c21cc0df