### PR TITLE
Add theme-aware borders to panels

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -9,7 +9,8 @@ export default function PanelCard({
 }) {
   const content = (
     <div
-      className={`relative w-full h-full overflow-hidden cursor-pointer group ${className}`}
+      className={`relative w-full h-full overflow-hidden cursor-pointer group border bg-[var(--background)] ${className}`}
+      style={{ borderColor: "var(--border)" }}
     >
       {imageSrc && (
         <img

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -5,7 +5,6 @@ export default function PanelGrid() {
     <div className="grid grid-rows-3 gap-4 w-full h-full">
       <div className="grid h-full grid-cols-1 gap-4">
         <PanelCard
-          className="bg-white h-full"
           imageSrc="https://via.placeholder.com/600x300?text=Read"
           label="READ"
           to="/read"
@@ -13,13 +12,11 @@ export default function PanelGrid() {
       </div>
       <div className="grid h-full grid-cols-2 gap-4">
         <PanelCard
-          className="bg-white h-full"
           imageSrc="https://via.placeholder.com/300x200?text=Buy"
           label="BUY"
           to="/buy"
         />
         <PanelCard
-          className="bg-white h-full"
           imageSrc="https://via.placeholder.com/300x200?text=World"
           label="WORLD"
           to="/world"
@@ -27,13 +24,13 @@ export default function PanelGrid() {
       </div>
       <div className="grid h-full grid-cols-3 gap-4">
         <PanelCard
-          className="bg-white h-full col-span-1"
+          className="col-span-1"
           imageSrc="https://via.placeholder.com/200x133?text=Team"
           label="TEAM"
           to="/team"
         />
         <PanelCard
-          className="bg-white h-full col-span-2"
+          className="col-span-2"
           imageSrc="https://via.placeholder.com/400x267?text=Contact"
           label="CONTACT"
           to="/contact"


### PR DESCRIPTION
## Summary
- Add border with theme-aware colors to `PanelCard`
- Remove hardcoded backgrounds in `PanelGrid` so panels inherit theme styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f79586d0c83219a6e290753e11451