### PR TITLE
fix: absolutely position panel images

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -16,7 +16,7 @@ export default function PanelCard({
         <img
           src={imageSrc}
           alt={label}
-          className="object-cover w-full h-full"
+          className="absolute inset-0 w-full h-full object-cover"
         />
       )}
       <div className="absolute inset-0 bg-black opacity-0 transition-opacity duration-300 group-hover:opacity-20 pointer-events-none" />


### PR DESCRIPTION
## Summary
- absolutely position PanelCard images to avoid affecting layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html".)*


------
https://chatgpt.com/codex/tasks/task_e_689f973465308321b9d22416bfb4c371