### PR TITLE
Simplify third row layout and enlarge panel labels

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -24,7 +24,7 @@ export default function PanelCard({
         <div className="absolute inset-0 flex items-center justify-center">
           <motion.span
             layoutId={label}
-            className="text-black font-bold uppercase text-center"
+            className="text-white font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}
           </motion.span>

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -31,15 +31,15 @@ export default function PanelGrid() {
           to="/world"
         />
       </div>
-      <div className="grid h-full grid-cols-3 gap-4">
+      <div className="grid h-full grid-cols-2 gap-4">
         <PanelCard
-          className="bg-white h-full col-span-1"
+          className="bg-white h-full"
           imageSrc={teamImg}
           label="TEAM"
           to="/team"
         />
         <PanelCard
-          className="bg-white h-full col-span-2"
+          className="bg-white h-full"
           imageSrc={contactImg}
           label="CONTACT"
           to="/contact"


### PR DESCRIPTION
## Summary
- Remove extra grid space in final row for a balanced two-panel layout
- Enlarge panel labels, color them white, and scale size responsively

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f9bac0868832197f399c42d84f06b