### PR TITLE
feat: add issue info panel

### DIFF
--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -1,0 +1,48 @@
+import { motion } from "framer-motion";
+
+export default function IssueInfoPanel({ issue }) {
+  if (!issue) {
+    return null;
+  }
+
+  return (
+    <motion.div
+      key={issue.id}
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 20 }}
+      className="flex flex-col items-center gap-4 p-4 mt-4 border rounded bg-[var(--background)]"
+      style={{ borderColor: "var(--border)" }}
+    >
+      {issue.cover && (
+        <img
+          src={issue.cover}
+          alt={issue.title}
+          className="w-full max-w-sm rounded"
+        />
+      )}
+      <div className="text-center">
+        <h2 className="text-2xl font-bold">
+          {issue.title}
+        </h2>
+        {issue.subtitle && (
+          <h3 className="text-lg text-gray-500">{issue.subtitle}</h3>
+        )}
+      </div>
+      {issue.description && (
+        <p className="max-w-xl text-center">{issue.description}</p>
+      )}
+      {issue.credits && (
+        <p className="text-sm text-gray-500 text-center">{issue.credits}</p>
+      )}
+      {issue.link && (
+        <a
+          href={issue.link}
+          className="px-4 py-2 mt-2 text-sm font-semibold text-white bg-blue-600 rounded hover:bg-blue-700"
+        >
+          Read this issue
+        </a>
+      )}
+    </motion.div>
+  );
+}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,15 +1,83 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import PanelContent from "../components/PanelContent";
-import { motion } from "framer-motion";
+import IssueInfoPanel from "../components/IssueInfoPanel";
+
+const issues = [
+  {
+    id: 1,
+    cover: "https://via.placeholder.com/400x600?text=Issue+1",
+    title: "Issue 1",
+    subtitle: "The Beginning",
+    description:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.",
+    credits: "Written by The Team",
+    link: "#",
+  },
+  {
+    id: 2,
+    cover: "https://via.placeholder.com/400x600?text=Issue+2",
+    title: "Issue 2",
+    subtitle: "The Sequel",
+    description:
+      "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo.",
+    credits: "Written by The Team",
+    link: "#",
+  },
+  {
+    id: 3,
+    cover: "https://via.placeholder.com/400x600?text=Issue+3",
+    title: "Issue 3",
+    subtitle: "The Finale",
+    description:
+      "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+    credits: "Written by The Team",
+    link: "#",
+  },
+];
 
 export default function Read() {
+  const [selectedIssue, setSelectedIssue] = useState(null);
+
+  const handleSelect = (issue) => {
+    setSelectedIssue((prev) => (prev?.id === issue.id ? null : issue));
+  };
+
   return (
     <PanelContent>
-      <motion.h1
-        layoutId="READ"
-        className="text-4xl font-bold uppercase"
-      >
-        READ
-      </motion.h1>
+      <div className="flex flex-col items-center w-full">
+        <motion.h1
+          layoutId="READ"
+          className="mb-4 text-4xl font-bold uppercase"
+        >
+          READ
+        </motion.h1>
+
+        <div className="flex w-full gap-4 overflow-x-auto pb-4 justify-center">
+          {issues.map((issue) => (
+            <button
+              key={issue.id}
+              type="button"
+              onClick={() => handleSelect(issue)}
+              className="flex-shrink-0 focus:outline-none"
+            >
+              <img
+                src={issue.cover}
+                alt={issue.title}
+                className={`h-40 w-28 object-cover border rounded ${
+                  selectedIssue?.id === issue.id
+                    ? "border-blue-500"
+                    : "border-transparent"
+                }`}
+              />
+            </button>
+          ))}
+        </div>
+
+        <AnimatePresence mode="wait">
+          {selectedIssue && <IssueInfoPanel issue={selectedIssue} key={selectedIssue.id} />}
+        </AnimatePresence>
+      </div>
     </PanelContent>
   );
 }


### PR DESCRIPTION
## Summary
- add animated IssueInfoPanel component
- show issue details below carousel on Read page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e4e8e3448321bc10d5ddae9ec231