### PR TITLE
Add fallback image component and replace img tags

### DIFF
--- a/src/components/ImageWithFallback.jsx
+++ b/src/components/ImageWithFallback.jsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+const FALLBACK_SRC = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGM4c+YMAATMAmU5mmUsAAAAAElFTkSuQmCC";
+
+export default function ImageWithFallback({ src, alt, className = "", ...props }) {
+  const [imgSrc, setImgSrc] = useState(src);
+
+  const handleError = () => {
+    setImgSrc(FALLBACK_SRC);
+  };
+
+  return (
+    <img
+      src={imgSrc}
+      onError={handleError}
+      alt={alt}
+      className={className}
+      {...props}
+    />
+  );
+}
+

--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -1,4 +1,5 @@
 import issues from "../data/issues";
+import ImageWithFallback from "./ImageWithFallback";
 
 export default function IssueCarousel({ selectedId, onSelect }) {
   return (
@@ -13,7 +14,7 @@ export default function IssueCarousel({ selectedId, onSelect }) {
             }`}
             style={{ borderColor: "var(--border)" }}
           >
-            <img
+            <ImageWithFallback
               src={issue.previewImage}
               alt={issue.title}
               className="w-full h-40 object-cover"

--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -1,5 +1,6 @@
 import { motion } from "framer-motion";
 import issues from "../data/issues";
+import ImageWithFallback from "./ImageWithFallback";
 
 export default function IssueInfoPanel({ issueId }) {
   const issue = issues.find((i) => i.id === issueId);
@@ -18,7 +19,7 @@ export default function IssueInfoPanel({ issueId }) {
       style={{ borderColor: "var(--border)" }}
     >
       {issue.coverImage && (
-        <img
+        <ImageWithFallback
           src={issue.coverImage}
           alt={issue.title}
           className="w-full max-w-sm rounded"

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
+import ImageWithFallback from "./ImageWithFallback";
 
 export default function PanelCard({
   className = "",
@@ -13,7 +14,7 @@ export default function PanelCard({
       style={{ borderColor: "var(--border)" }}
     >
       {imageSrc && (
-        <img
+        <ImageWithFallback
           src={imageSrc}
           alt={label}
           className="absolute inset-0 w-full h-full object-cover"

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -4,6 +4,7 @@ import PanelContent from "../components/PanelContent";
 import IssueCarousel from "../components/IssueCarousel";
 import IssueInfoPanel from "../components/IssueInfoPanel";
 import heroImage from "../assets/read/hero.jpg";
+import ImageWithFallback from "../components/ImageWithFallback";
 
 export default function Read() {
   const [selectedIssueId, setSelectedIssueId] = useState(null);
@@ -19,7 +20,7 @@ export default function Read() {
         layoutId="READ"
         className="relative w-full h-[75vh] md:h-screen"
       >
-        <img
+        <ImageWithFallback
           src={heroImage}
           alt=""
           aria-hidden="true"


### PR DESCRIPTION
## Summary
- add `ImageWithFallback` component that swaps to a grey placeholder if an image fails to load
- use `ImageWithFallback` instead of `<img>` in Read page and related components

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html" )*


------
https://chatgpt.com/codex/tasks/task_e_68a0ea0181dc8321abc2dfc39ef03bcf