### PR TITLE
Use JPG paths for home page panels

### DIFF
--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,9 +1,9 @@
 import PanelCard from "./PanelCard";
-const readImg = "/panels/read.png";
-const buyImg = "/panels/buy.png";
-const worldImg = "/panels/world.png";
-const teamImg = "/panels/team.png";
-const contactImg = "/panels/contact.png";
+const readImg = "/panels/read.jpg";
+const buyImg = "/panels/buy.jpg";
+const worldImg = "/panels/world.jpg";
+const teamImg = "/panels/team.jpg";
+const contactImg = "/panels/contact.jpg";
 
 export default function PanelGrid() {
   return (


### PR DESCRIPTION
## Summary
- point home page panel cards to `/panels/*.jpg` images instead of PNGs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eff79c0883219c04fca08512aeb7