### PR TITLE
Use grey placeholder when images fail to load

### DIFF
--- a/src/components/ImageWithFallback.jsx
+++ b/src/components/ImageWithFallback.jsx
@@ -1,18 +1,27 @@
-import { useState } from "react";
-
-const FALLBACK_SRC = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGM4c+YMAATMAmU5mmUsAAAAAElFTkSuQmCC";
+import { useEffect, useState } from "react";
 
 export default function ImageWithFallback({ src, alt, className = "", ...props }) {
-  const [imgSrc, setImgSrc] = useState(src);
+  const [hasError, setHasError] = useState(!src);
 
-  const handleError = () => {
-    setImgSrc(FALLBACK_SRC);
-  };
+  useEffect(() => {
+    setHasError(!src);
+  }, [src]);
+
+  if (hasError) {
+    return (
+      <div
+        role="img"
+        aria-label={alt}
+        className={`bg-gray-400 ${className}`}
+        {...props}
+      />
+    );
+  }
 
   return (
     <img
-      src={imgSrc}
-      onError={handleError}
+      src={src}
+      onError={() => setHasError(true)}
       alt={alt}
       className={className}
       {...props}


### PR DESCRIPTION
## Summary
- show a gray background placeholder when images are missing or fail to load by updating ImageWithFallback component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*


------
https://chatgpt.com/codex/tasks/task_e_68a0f2667c608321ad666ef9c9d9d648