### PR TITLE
Remove static hero image import in Read page

### DIFF
--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -3,7 +3,6 @@ import { motion, AnimatePresence } from "framer-motion";
 import PanelContent from "../components/PanelContent";
 import IssueCarousel from "../components/IssueCarousel";
 import IssueInfoPanel from "../components/IssueInfoPanel";
-import heroImage from "../assets/read/hero.jpg";
 import ImageWithFallback from "../components/ImageWithFallback";
 
 export default function Read() {
@@ -21,7 +20,7 @@ export default function Read() {
         className="relative w-full h-[75vh] md:h-screen"
       >
         <ImageWithFallback
-          src={heroImage}
+          src="/read/hero.jpg"
           alt=""
           aria-hidden="true"
           className="absolute inset-0 w-full h-full object-cover"


### PR DESCRIPTION
## Summary
- load Read page hero image from public path instead of static import
- rely on ImageWithFallback for placeholder when `/read/hero.jpg` is absent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f39e0b18832188934cd05411e7a4