### PR TITLE
Align Read page hero to top

### DIFF
--- a/src/components/PanelContent.jsx
+++ b/src/components/PanelContent.jsx
@@ -1,3 +1,7 @@
-export default function PanelContent({ children }) {
-  return <div className="flex items-center justify-center w-full h-full">{children}</div>;
+export default function PanelContent({ children, className = "" }) {
+  return (
+    <div className={`flex flex-col items-center justify-center w-full h-full ${className}`}>
+      {children}
+    </div>
+  );
 }

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -13,7 +13,7 @@ export default function Read() {
   };
 
   return (
-    <PanelContent>
+    <PanelContent className="items-start justify-start">
       {/* Hero Section */}
       <motion.section
         layoutId="READ"
@@ -26,14 +26,16 @@ export default function Read() {
           className="absolute inset-0 w-full h-full object-cover"
         />
         <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
-        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center text-white">
-          <h1 className="text-4xl md:text-6xl font-bold uppercase">Read</h1>
-          <p className="mt-4 text-lg md:text-2xl max-w-xl">
-            Explore the latest issue of Renowned Home.
-          </p>
+        <div className="relative flex flex-col items-start w-full h-full p-4 text-white">
+          <div className="flex w-full items-center justify-between">
+            <h1 className="text-4xl md:text-6xl font-bold uppercase">READ</h1>
+            <p className="text-lg md:text-2xl max-w-xl text-right">
+              Explore the latest issue of Renowned Home.
+            </p>
+          </div>
           <a
             href="https://flipbook.example.com/full-issue"
-            className="mt-8 px-6 py-3 text-base font-semibold bg-blue-600 hover:bg-blue-700 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+            className="mt-8 self-start px-6 py-3 text-base font-semibold bg-blue-600 hover:bg-blue-700 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Summary
- Allow PanelContent to accept custom alignment
- Position Read page hero at top with inline description

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68a0fbf57314832184d8c483d24b40b1