### PR TITLE
Center Read hero content

### DIFF
--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -26,16 +26,16 @@ export default function Read() {
           className="absolute inset-0 w-full h-full object-cover"
         />
         <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
-        <div className="relative flex flex-col items-start w-full h-full p-4 text-white">
-          <div className="flex w-full items-center justify-between">
-            <h1 className="text-4xl md:text-6xl font-bold uppercase">READ</h1>
-            <p className="text-lg md:text-2xl max-w-xl text-right">
+        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-white text-center">
+          <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
+            <h1 className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]">READ</h1>
+            <p className="text-lg md:text-2xl max-w-xl text-center">
               Explore the latest issue of Renowned Home.
             </p>
           </div>
           <a
             href="https://flipbook.example.com/full-issue"
-            className="mt-8 self-start px-6 py-3 text-base font-semibold bg-blue-600 hover:bg-blue-700 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+            className="mt-8 px-6 py-3 text-base font-semibold bg-blue-600 hover:bg-blue-700 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Summary
- Center Read page hero label and description with responsive layout
- Enlarge READ label and add padding for better emphasis

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fd6d4b308321bfb9e2e587700dcb