### PR TITLE
Make home button image centered on panel junction

### DIFF
--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -1,20 +1,18 @@
-import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { motion } from "framer-motion";
+import ImageWithFallback from "./ImageWithFallback";
 
 export default function BackButton() {
-  const [hovered, setHovered] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
   const isHome = location.pathname === "/";
 
   const positionClasses = isHome
-    ? "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+    ? "left-1/2 top-[66%] -translate-x-1/2 -translate-y-1/2"
     : "left-4 top-4";
-  const bgClass = hovered ? "bg-faded-rust/80" : "bg-faded-rust";
   const baseClasses =
-    "absolute w-12 h-12 rounded-full text-soft-bone border-[1rem] transition-colors duration-200";
-  const className = `${baseClasses} ${positionClasses} ${bgClass}`;
+    "absolute w-12 h-12 rounded-full border overflow-hidden transition-colors duration-200";
+  const className = `${baseClasses} ${positionClasses}`;
 
   return (
     <motion.button
@@ -22,14 +20,16 @@ export default function BackButton() {
       type="button"
       className={className}
       style={{ borderColor: "var(--border)" }}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
       onClick={() => navigate(-1)}
       initial={{ opacity: 0, scale: 0.9 }}
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.9 }}
     >
-      Base
+      <ImageWithFallback
+        src="/panels/home.jpg"
+        alt="Home"
+        className="w-full h-full object-cover"
+      />
     </motion.button>
   );
 }


### PR DESCRIPTION
## Summary
- Replace text-based home/back button with circular image button and thin border
- Position the home button at the center intersection of the four lower panels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_68a1093a3ba483219251958acdbea0af