### PR TITLE
chore: swap world and read panels

### DIFF
--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -11,9 +11,9 @@ export default function PanelGrid() {
       <div className="grid h-full grid-cols-1 gap-4">
         <PanelCard
           className="bg-white h-full"
-          imageSrc={readImg || undefined}
-          label="READ"
-          to="/read"
+          imageSrc={worldImg || undefined}
+          label="WORLD"
+          to="/world"
         />
       </div>
       <div className="grid h-full grid-cols-2 gap-4">
@@ -25,9 +25,9 @@ export default function PanelGrid() {
         />
         <PanelCard
           className="bg-white h-full"
-          imageSrc={worldImg || undefined}
-          label="WORLD"
-          to="/world"
+          imageSrc={readImg || undefined}
+          label="READ"
+          to="/read"
         />
       </div>
       <div className="grid h-full grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- swap positions of WORLD and READ panels on the home grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a11b562ba48321b1fec9b99bffb675