### PR TITLE
Rename world and contact panels to EXPLORE and REACH

### DIFF
--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -12,7 +12,7 @@ export default function PanelGrid() {
         <PanelCard
           className="bg-white h-full"
           imageSrc={worldImg || undefined}
-          label="WORLD"
+          label="EXPLORE"
           to="/world"
         />
       </div>
@@ -40,7 +40,7 @@ export default function PanelGrid() {
         <PanelCard
           className="bg-white h-full"
           imageSrc={contactImg || undefined}
-          label="CONTACT"
+          label="REACH"
           to="/contact"
         />
       </div>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -5,10 +5,10 @@ export default function Contact() {
   return (
     <PanelContent>
       <motion.h1
-        layoutId="CONTACT"
+        layoutId="REACH"
         className="text-4xl font-bold uppercase"
       >
-        CONTACT
+        REACH
       </motion.h1>
     </PanelContent>
   );

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -5,10 +5,10 @@ export default function World() {
   return (
     <PanelContent>
       <motion.h1
-        layoutId="WORLD"
+        layoutId="EXPLORE"
         className="text-4xl font-bold uppercase"
       >
-        WORLD
+        EXPLORE
       </motion.h1>
     </PanelContent>
   );


### PR DESCRIPTION
## Summary
- replace World panel label with EXPLORE across grid and page
- rename Contact panel label to REACH and update matching layout ids

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a121a67d0c8321b4410cd92d5db419