### PR TITLE
feat: apply custom font families

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;700&family=Nunito+Sans:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <title>Renowned Site</title>
   </head>
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -19,8 +19,21 @@
   --border: #1e293b;
 }
 
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  label {
+    @apply font-hero;
+  }
+}
+
 body {
   background-color: var(--background);
   color: var(--foreground);
   overflow: hidden;
+  @apply font-sans;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,10 @@ export default {
         "aged-brass": "#C9A66B",
         "desaturated-blood": "#8A3B3B",
       },
+      fontFamily: {
+        hero: ["'Josefin Sans'", "sans-serif"],
+        sans: ["'Nunito Sans'", "sans-serif"],
+      },
     },
   },
   plugins: [forms],


### PR DESCRIPTION
## Summary
- load Josefin Sans and Nunito Sans from Google Fonts
- set Josefin Sans for headers and labels with Tailwind
- make Nunito Sans the default UI and body font

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1214791ec832191e58afb817f4324