### PR TITLE
Ensure labels persist while subpage content fades in

### DIFF
--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -4,23 +4,31 @@ import { motion } from "framer-motion";
 export default function Buy() {
   return (
     <PanelContent className="items-start justify-start">
-      <motion.section
-        layoutId="BUY"
-        className="flex flex-col items-center justify-center w-full h-screen p-4 text-center gap-4"
-      >
-        <h1 className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]">
+      <section className="flex flex-col items-center justify-center w-full h-screen p-4 text-center gap-4">
+        <motion.h1
+          layoutId="BUY"
+          className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+        >
           BUY
-        </h1>
-        <p className="text-lg md:text-2xl max-w-xl">
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.2 }}
+          className="text-lg md:text-2xl max-w-xl"
+        >
           Support Renowned Home by backing our upcoming Kickstarter campaign.
-        </p>
-        <a
+        </motion.p>
+        <motion.a
           href="#"
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.4 }}
           className="mt-4 px-8 py-3 font-bold uppercase bg-black text-white rounded"
         >
           KICKSTARTER
-        </a>
-      </motion.section>
+        </motion.a>
+      </section>
     </PanelContent>
   );
 }

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -16,8 +16,10 @@ export default function Read() {
     <PanelContent className="items-start justify-start">
       {/* Hero Section */}
       <motion.section
-        layoutId="READ"
         className="relative w-full h-[75vh] md:h-screen flex-shrink-0"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
       >
         <ImageWithFallback
           src="/read/hero.jpg"
@@ -28,23 +30,38 @@ export default function Read() {
         <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-white text-center">
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
-            <h1 className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]">READ</h1>
-            <p className="text-lg md:text-2xl max-w-xl text-center">
+            <motion.h1
+              layoutId="READ"
+              className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            >
+              READ
+            </motion.h1>
+            <motion.p
+              initial={{ opacity: 0, y: -20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.2 }}
+              className="text-lg md:text-2xl max-w-xl text-center"
+            >
               Explore the latest issue of Renowned Home.
-            </p>
+            </motion.p>
           </div>
         </div>
       </motion.section>
 
       {/* Carousel + Info Section */}
-      <div className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8">
+      <motion.div
+        className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.4 }}
+      >
         <IssueCarousel selectedId={selectedIssueId} onSelect={handleSelect} />
         <AnimatePresence mode="wait">
           {selectedIssueId && (
             <IssueInfoPanel issueId={selectedIssueId} key={selectedIssueId} />
           )}
         </AnimatePresence>
-      </div>
+      </motion.div>
     </PanelContent>
   );
 }


### PR DESCRIPTION
## Summary
- Limit shared layout transitions to page labels only
- Add top-to-bottom fade-in animations for buy page text and link
- Animate read page hero and carousel content sequentially

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a12473ce9c83219fc5dbe8bcf5e764