### PR TITLE
Add Meet page team carousel and bios

### DIFF
--- a/src/components/TeamCarousel.jsx
+++ b/src/components/TeamCarousel.jsx
@@ -1,0 +1,43 @@
+import team from "../data/team";
+import ImageWithFallback from "./ImageWithFallback";
+import { motion } from "framer-motion";
+
+export default function TeamCarousel({ selectedId, onSelect }) {
+  const hideLabels = selectedId !== null;
+  return (
+    <div className="w-full overflow-x-auto touch-pan-x">
+      <div className="flex space-x-6 p-4 justify-center">
+        {team.map((member) => (
+          <div
+            key={member.id}
+            className="flex flex-col items-center flex-shrink-0"
+          >
+            <div
+              onClick={() => onSelect?.(member.id)}
+              className={`w-32 h-32 rounded-full border overflow-hidden cursor-pointer transition-transform ${
+                selectedId === member.id
+                  ? "ring-2 ring-[var(--accent)] scale-105"
+                  : "hover:scale-105"
+              }`}
+              style={{ borderColor: "var(--border)" }}
+            >
+              <ImageWithFallback
+                src={member.image}
+                alt={member.role}
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <motion.p
+              className="mt-2 text-center text-sm"
+              initial={false}
+              animate={{ opacity: hideLabels ? 0 : 1 }}
+              transition={{ duration: 0.3 }}
+            >
+              {member.role}
+            </motion.p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TeamInfoPanel.jsx
+++ b/src/components/TeamInfoPanel.jsx
@@ -1,0 +1,33 @@
+import { motion } from "framer-motion";
+import team from "../data/team";
+import ImageWithFallback from "./ImageWithFallback";
+
+export default function TeamInfoPanel({ memberId }) {
+  const member = team.find((m) => m.id === memberId);
+
+  if (!member) {
+    return null;
+  }
+
+  return (
+    <motion.div
+      key={member.id}
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 20 }}
+      className="flex flex-col items-center gap-4 p-4 mt-4 border rounded bg-[var(--background)]"
+      style={{ borderColor: "var(--border)" }}
+    >
+      <ImageWithFallback
+        src={member.image}
+        alt={member.name}
+        className="w-full max-w-sm rounded"
+      />
+      <div className="text-center">
+        <h2 className="text-2xl font-bold">{member.name}</h2>
+        <h3 className="text-lg text-gray-500">{member.role}</h3>
+      </div>
+      {member.bio && <p className="max-w-xl text-center">{member.bio}</p>}
+    </motion.div>
+  );
+}

--- a/src/data/team.js
+++ b/src/data/team.js
@@ -1,0 +1,25 @@
+const team = [
+  {
+    id: 'writer',
+    role: 'Writer',
+    name: 'Alex Writer',
+    image: 'https://via.placeholder.com/300x300?text=Writer',
+    bio: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.',
+  },
+  {
+    id: 'artist',
+    role: 'Artist',
+    name: 'Sam Artist',
+    image: 'https://via.placeholder.com/300x300?text=Artist',
+    bio: 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo.',
+  },
+  {
+    id: 'colorist',
+    role: 'Colorist',
+    name: 'Lee Colorist',
+    image: 'https://via.placeholder.com/300x300?text=Colorist',
+    bio: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+  },
+];
+
+export default team;

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -1,15 +1,50 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import PanelContent from "../components/PanelContent";
-import { motion } from "framer-motion";
+import TeamCarousel from "../components/TeamCarousel";
+import TeamInfoPanel from "../components/TeamInfoPanel";
+import ImageWithFallback from "../components/ImageWithFallback";
 
 export default function Meet() {
+  const [selectedMemberId, setSelectedMemberId] = useState(null);
+
+  const handleSelect = (id) => {
+    setSelectedMemberId((prev) => (prev === id ? null : id));
+  };
+
   return (
-    <PanelContent>
-      <motion.h1
+    <PanelContent className="items-start justify-start">
+      {/* Hero Section */}
+      <motion.section
         layoutId="MEET"
-        className="text-4xl font-bold uppercase"
+        className="relative w-full h-[75vh] md:h-screen flex-shrink-0"
       >
-        MEET
-      </motion.h1>
+        <ImageWithFallback
+          src="/meet/hero.jpg"
+          alt=""
+          aria-hidden="true"
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+        <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-white text-center">
+          <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
+            <h1 className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]">MEET</h1>
+            <p className="text-lg md:text-2xl max-w-xl text-center">
+              Learn about the team behind Renowned Home.
+            </p>
+          </div>
+        </div>
+      </motion.section>
+
+      {/* Carousel + Info Section */}
+      <div className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8">
+        <TeamCarousel selectedId={selectedMemberId} onSelect={handleSelect} />
+        <AnimatePresence mode="wait">
+          {selectedMemberId && (
+            <TeamInfoPanel memberId={selectedMemberId} key={selectedMemberId} />
+          )}
+        </AnimatePresence>
+      </div>
     </PanelContent>
   );
 }


### PR DESCRIPTION
## Summary
- Introduce `team` data with writer, artist, and colorist bios
- Create `TeamCarousel` and `TeamInfoPanel` components for interactive bios
- Expand Meet page with hero section and team carousel/bio panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*


------
https://chatgpt.com/codex/tasks/task_e_68a125ae04208321bbfc5d45f683f386