### PR TITLE
Ensure sub-pages fade non-label content

### DIFF
--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -4,7 +4,12 @@ import { motion } from "framer-motion";
 export default function Buy() {
   return (
     <PanelContent className="items-start justify-start">
-      <section className="flex flex-col items-center justify-center w-full h-screen p-4 text-center gap-4">
+      <motion.section
+        className="flex flex-col items-center justify-center w-full h-screen p-4 text-center gap-4"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
         <motion.h1
           layoutId="BUY"
           className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
@@ -28,7 +33,7 @@ export default function Buy() {
         >
           KICKSTARTER
         </motion.a>
-      </section>
+      </motion.section>
     </PanelContent>
   );
 }

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -16,8 +16,10 @@ export default function Meet() {
     <PanelContent className="items-start justify-start">
       {/* Hero Section */}
       <motion.section
-        layoutId="MEET"
         className="relative w-full h-[75vh] md:h-screen flex-shrink-0"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
       >
         <ImageWithFallback
           src="/meet/hero.jpg"
@@ -28,23 +30,38 @@ export default function Meet() {
         <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-white text-center">
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
-            <h1 className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]">MEET</h1>
-            <p className="text-lg md:text-2xl max-w-xl text-center">
+            <motion.h1
+              layoutId="MEET"
+              className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            >
+              MEET
+            </motion.h1>
+            <motion.p
+              initial={{ opacity: 0, y: -20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.2 }}
+              className="text-lg md:text-2xl max-w-xl text-center"
+            >
               Learn about the team behind Renowned Home.
-            </p>
+            </motion.p>
           </div>
         </div>
       </motion.section>
 
       {/* Carousel + Info Section */}
-      <div className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8">
+      <motion.div
+        className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.4 }}
+      >
         <TeamCarousel selectedId={selectedMemberId} onSelect={handleSelect} />
         <AnimatePresence mode="wait">
           {selectedMemberId && (
             <TeamInfoPanel memberId={selectedMemberId} key={selectedMemberId} />
           )}
         </AnimatePresence>
-      </div>
+      </motion.div>
     </PanelContent>
   );
 }


### PR DESCRIPTION
## Summary
- Fade `Buy` page content and keep only the label transferring between routes.
- Update `Meet` page hero and details sections to fade, with only the label using layoutId.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a127831e508321a584ba99bab8934e