### PR TITLE
Define full and half hero layouts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -37,3 +37,13 @@ body {
   overflow: hidden;
   @apply font-sans;
 }
+
+@layer components {
+  .hero-full {
+    @apply w-full h-screen;
+  }
+
+  .hero-half {
+    @apply w-full h-[50vh];
+  }
+}

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -5,7 +5,7 @@ export default function Buy() {
   return (
     <PanelContent className="items-start justify-start">
       <motion.section
-        className="flex flex-col items-center justify-center w-full h-screen p-4 text-center gap-4"
+        className="flex flex-col items-center justify-center p-4 text-center gap-4 hero-full"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -3,13 +3,20 @@ import { motion } from "framer-motion";
 
 export default function Contact() {
   return (
-    <PanelContent>
-      <motion.h1
-        layoutId="REACH"
-        className="text-4xl font-bold uppercase"
+    <PanelContent className="items-start justify-start">
+      <motion.section
+        className="flex items-center justify-center hero-half"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
       >
-        REACH
-      </motion.h1>
+        <motion.h1
+          layoutId="REACH"
+          className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+        >
+          REACH
+        </motion.h1>
+      </motion.section>
     </PanelContent>
   );
 }

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -16,7 +16,7 @@ export default function Meet() {
     <PanelContent className="items-start justify-start">
       {/* Hero Section */}
       <motion.section
-        className="relative w-full h-[75vh] md:h-screen flex-shrink-0"
+        className="relative flex-shrink-0 hero-half"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -16,7 +16,7 @@ export default function Read() {
     <PanelContent className="items-start justify-start">
       {/* Hero Section */}
       <motion.section
-        className="relative w-full h-[75vh] md:h-screen flex-shrink-0"
+        className="relative flex-shrink-0 hero-half"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -3,13 +3,20 @@ import { motion } from "framer-motion";
 
 export default function World() {
   return (
-    <PanelContent>
-      <motion.h1
-        layoutId="EXPLORE"
-        className="text-4xl font-bold uppercase"
+    <PanelContent className="items-start justify-start">
+      <motion.section
+        className="flex items-center justify-center hero-full"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
       >
-        EXPLORE
-      </motion.h1>
+        <motion.h1
+          layoutId="EXPLORE"
+          className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+        >
+          EXPLORE
+        </motion.h1>
+      </motion.section>
     </PanelContent>
   );
 }


### PR DESCRIPTION
## Summary
- add `hero-full` and `hero-half` utility classes for consistent hero sizing
- apply `hero-full` to Explore and Buy pages and `hero-half` to Read, Meet, and Reach pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a12d1ccd288321a2b5035b265123e9