### PR TITLE
Ensure panel labels overlay during transitions

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -25,7 +25,7 @@ export default function PanelCard({
         <div className="absolute inset-0 flex items-center justify-center">
           <motion.span
             layoutId={label}
-            className="text-white font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
+            className="relative z-50 text-white font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}
           </motion.span>

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -12,7 +12,7 @@ export default function Buy() {
       >
         <motion.h1
           layoutId="BUY"
-          className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
         >
           BUY
         </motion.h1>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -6,7 +6,7 @@ export default function Contact() {
     <PanelContent>
       <motion.h1
         layoutId="REACH"
-        className="text-4xl font-bold uppercase"
+        className="relative z-50 text-4xl font-bold uppercase"
       >
         REACH
       </motion.h1>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -32,7 +32,7 @@ export default function Meet() {
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
             <motion.h1
               layoutId="MEET"
-              className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
             >
               MEET
             </motion.h1>

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -32,7 +32,7 @@ export default function Read() {
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
             <motion.h1
               layoutId="READ"
-              className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
             >
               READ
             </motion.h1>

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -6,7 +6,7 @@ export default function World() {
     <PanelContent>
       <motion.h1
         layoutId="EXPLORE"
-        className="text-4xl font-bold uppercase"
+        className="relative z-50 text-4xl font-bold uppercase"
       >
         EXPLORE
       </motion.h1>


### PR DESCRIPTION
## Summary
- Keep panel labels visible by giving them a high z-index.
- Apply the same z-index styling to subpage headings so labels stay on top when navigating.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_68a12d2589e483218823c939a97894bd