### PR TITLE
Ensure panel labels and headings appear above backgrounds

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -25,7 +25,7 @@ export default function PanelCard({
         <div className="absolute inset-0 flex items-center justify-center">
           <motion.span
             layoutId={label}
-            className="text-white font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
+            className="relative z-50 text-white font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}
           </motion.span>

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -12,7 +12,7 @@ export default function Buy() {
       >
         <motion.h1
           layoutId="BUY"
-          className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
         >
           BUY
         </motion.h1>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -32,7 +32,7 @@ export default function Meet() {
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
             <motion.h1
               layoutId="MEET"
-              className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
             >
               MEET
             </motion.h1>

--- a/src/pages/Reach.jsx
+++ b/src/pages/Reach.jsx
@@ -10,7 +10,7 @@ export default function Reach() {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <div className="flex-1 flex flex-col items-center justify-center p-4">
-        <motion.h1 layoutId="REACH" className="text-4xl font-bold uppercase mb-4">
+        <motion.h1 layoutId="REACH" className="relative z-50 text-4xl font-bold uppercase mb-4">
           REACH
         </motion.h1>
         <form className="flex w-full max-w-md">

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -32,7 +32,7 @@ export default function Read() {
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
             <motion.h1
               layoutId="READ"
-              className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
             >
               READ
             </motion.h1>

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -12,7 +12,7 @@ export default function World() {
       >
         <motion.h1
           layoutId="EXPLORE"
-          className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
         >
           EXPLORE
         </motion.h1>

--- a/src/pages/reach.jsx
+++ b/src/pages/reach.jsx
@@ -12,7 +12,7 @@ export default function Reach() {
       >
         <motion.h1
           layoutId="REACH"
-          className="px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
         >
           REACH
         </motion.h1>


### PR DESCRIPTION
## Summary
- Keep panel labels visible by giving motion span a relative position with high z-index
- Apply the same z-index to subpage headings so labels stay on top when navigating back home

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a134dd332c83219a06efa09ab3c920