### PR TITLE
Add welcome panel and remove home button

### DIFF
--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -6,10 +6,12 @@ export default function BackButton() {
   const navigate = useNavigate();
   const location = useLocation();
   const isHome = location.pathname === "/";
+  if (isHome) {
+    return null;
+  }
 
-  const positionClasses = isHome
-    ? "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
-    : "left-1/2 top-1/2 -translate-x-[calc(100%+1rem)] -translate-y-1/2";
+  const positionClasses =
+    "left-1/2 top-1/2 -translate-x-[calc(100%+1rem)] -translate-y-1/2";
   const baseClasses =
     "absolute w-12 h-12 rounded-full border overflow-hidden transition-colors duration-200";
   const className = `${baseClasses} ${positionClasses}`;

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -30,19 +30,27 @@ export default function PanelGrid() {
           to="/read"
         />
       </div>
-      <div className="grid h-full grid-cols-2 gap-4">
-          <PanelCard
-            className="bg-white h-full"
-            imageSrc={meetImg || undefined}
-            label="MEET"
-            to="/meet"
-          />
+      <div className="grid h-full grid-cols-3 gap-4">
+        <PanelCard
+          className="bg-white h-full"
+          imageSrc={meetImg || undefined}
+          label="MEET"
+          to="/meet"
+        />
         <PanelCard
           className="bg-white h-full"
           imageSrc={reachImg || undefined}
           label="REACH"
           to="/reach"
         />
+        <div
+          className="relative w-full h-full border bg-white flex items-center justify-center"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <span className="font-bold text-black uppercase text-center text-[clamp(2rem,5vw,6rem)]">
+            WELCOME
+          </span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add third 'WELCOME' panel to bottom row of home page
- Hide circular home button when on the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a135c3aba0832185f641af37b3d671