### PR TITLE
Show logo on home page tile

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#e5e7eb" />
+  <text x="50" y="55" font-size="20" text-anchor="middle" fill="#374151">Logo</text>
+</svg>

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -51,13 +51,10 @@ export default function PanelGrid() {
           style={{ borderColor: "var(--border)" }}
         >
           <ImageWithFallback
-            src="/panels/home.jpg"
-            alt="Home"
-            className="absolute inset-0 w-full h-full object-cover"
+            src="/logo.svg"
+            alt="Logo"
+            className="w-3/4 h-3/4 object-contain"
           />
-          <span className="relative font-bold text-black uppercase text-center text-[clamp(2rem,5vw,6rem)]">
-            WELCOME
-          </span>
         </motion.div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace welcome tile in PanelGrid with centered logo placeholder
- add simple SVG logo asset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a13a6c68748321bd8c8c47bda9f57d