### PR TITLE
Refactor home logo button placement

### DIFF
--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -28,9 +28,9 @@ export default function BackButton() {
       exit={{ opacity: 0, scale: 0.9 }}
     >
       <ImageWithFallback
-        src="/panels/home.jpg"
-        alt="Home"
-        className="w-full h-full object-cover"
+        src="/logo.png"
+        alt="Logo"
+        className="w-full h-full object-contain"
       />
     </motion.button>
   );

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -10,13 +10,24 @@ const reachImg = "/panels/reach.jpg";
 export default function PanelGrid() {
   return (
     <div className="grid grid-rows-3 gap-4 w-full h-full">
-      <div className="grid h-full grid-cols-1 gap-4">
+      <div className="relative grid h-full grid-cols-1 gap-4">
         <PanelCard
           className="bg-white h-full"
           imageSrc={worldImg || undefined}
           label="EXPLORE"
           to="/world"
         />
+        <motion.div
+          layoutId="back-button"
+          className="absolute top-4 right-4 w-12 h-12 rounded-full border bg-white flex items-center justify-center overflow-hidden"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <ImageWithFallback
+            src="/logo.png"
+            alt="Logo"
+            className="w-full h-full object-contain"
+          />
+        </motion.div>
       </div>
       <div className="grid h-full grid-cols-2 gap-4">
         <PanelCard
@@ -32,7 +43,7 @@ export default function PanelGrid() {
           to="/read"
         />
       </div>
-      <div className="grid h-full grid-cols-3 gap-4">
+      <div className="grid h-full grid-cols-2 gap-4">
         <PanelCard
           className="bg-white h-full"
           imageSrc={meetImg || undefined}
@@ -45,17 +56,6 @@ export default function PanelGrid() {
           label="REACH"
           to="/reach"
         />
-        <motion.div
-          layoutId="back-button"
-          className="relative w-full h-full border bg-white flex items-center justify-center overflow-hidden"
-          style={{ borderColor: "var(--border)" }}
-        >
-          <ImageWithFallback
-            src="/logo.png"
-            alt="Logo"
-            className="w-3/4 h-3/4 object-contain"
-          />
-        </motion.div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Reposition home logo button to top row and animate into panel labels
- Simplify third row to Meet and Reach panels only
- Use logo asset for back button across pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a14569091c832184b3346a9f343183