### PR TITLE
Add grey-to-white gradient backgrounds for hero sections

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -40,10 +40,10 @@ body {
 
 @layer components {
   .hero-full {
-    @apply w-full h-screen;
+    @apply w-full h-screen bg-gradient-to-b from-gray-400 to-white;
   }
 
   .hero-half {
-    @apply w-full h-[50vh];
+    @apply w-full h-[50vh] bg-gradient-to-b from-gray-400 to-white;
   }
 }

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -3,7 +3,6 @@ import { motion, AnimatePresence } from "framer-motion";
 import PanelContent from "../components/PanelContent";
 import TeamCarousel from "../components/TeamCarousel";
 import TeamInfoPanel from "../components/TeamInfoPanel";
-import ImageWithFallback from "../components/ImageWithFallback";
 
 export default function Meet() {
   const [selectedMemberId, setSelectedMemberId] = useState(null);
@@ -21,14 +20,7 @@ export default function Meet() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <ImageWithFallback
-          src="/meet/hero.jpg"
-          alt=""
-          aria-hidden="true"
-          className="absolute inset-0 w-full h-full object-cover"
-        />
-        <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
-        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-white text-center">
+        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
             <motion.h1
               layoutId="MEET"

--- a/src/pages/Reach.jsx
+++ b/src/pages/Reach.jsx
@@ -1,5 +1,4 @@
 import PanelContent from "../components/PanelContent";
-import ImageWithFallback from "../components/ImageWithFallback";
 import { motion } from "framer-motion";
 
 export default function Reach() {
@@ -18,14 +17,7 @@ export default function Reach() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <ImageWithFallback
-          src="/reach/hero.jpg"
-          alt=""
-          aria-hidden="true"
-          className="absolute inset-0 w-full h-full object-cover"
-        />
-        <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
-        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-white text-center gap-4">
+        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center gap-4">
           <motion.h1
             layoutId="REACH"
             className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -3,7 +3,6 @@ import { motion, AnimatePresence } from "framer-motion";
 import PanelContent from "../components/PanelContent";
 import IssueCarousel from "../components/IssueCarousel";
 import IssueInfoPanel from "../components/IssueInfoPanel";
-import ImageWithFallback from "../components/ImageWithFallback";
 
 export default function Read() {
   const [selectedIssueId, setSelectedIssueId] = useState(null);
@@ -21,14 +20,7 @@ export default function Read() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <ImageWithFallback
-          src="/read/hero.jpg"
-          alt=""
-          aria-hidden="true"
-          className="absolute inset-0 w-full h-full object-cover"
-        />
-        <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
-        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-white text-center">
+        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
             <motion.h1
               layoutId="READ"


### PR DESCRIPTION
## Summary
- add vertical grey-to-white gradient styles for `hero` classes
- drop image backgrounds from hero sections in Meet, Reach and Read pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1485b98b88321b6f645fa1fe9b0b0