### PR TITLE
Refactor BackButton placement to pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import { Suspense, lazy } from "react";
-import { Routes, Route, Navigate, useLocation } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 import { LayoutGroup } from "framer-motion";
-import BackButton from "./components/BackButton";
 
 const PanelGrid = lazy(() => import("./components/PanelGrid"));
 const Read = lazy(() => import("./pages/Read"));
@@ -11,8 +10,6 @@ const Meet = lazy(() => import("./pages/Meet"));
 const Reach = lazy(() => import("./pages/Reach"));
 
 export default function App() {
-  const location = useLocation();
-
   return (
     <div
       className="relative w-screen h-screen overflow-x-hidden overflow-y-auto border-4 p-4"
@@ -30,7 +27,6 @@ export default function App() {
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </Suspense>
-        <BackButton />
       </LayoutGroup>
     </div>
   );

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,9 +1,11 @@
 import PanelContent from "../components/PanelContent";
+import BackButton from "../components/BackButton";
 import { motion } from "framer-motion";
 
 export default function Buy() {
   return (
     <PanelContent className="items-start justify-start">
+      <BackButton />
       <motion.section
         className="flex flex-col items-center justify-center p-4 text-center gap-4 hero-full"
         initial={{ opacity: 0, y: -20 }}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import PanelContent from "../components/PanelContent";
+import BackButton from "../components/BackButton";
 import TeamCarousel from "../components/TeamCarousel";
 import TeamInfoPanel from "../components/TeamInfoPanel";
 
@@ -13,6 +14,7 @@ export default function Meet() {
 
   return (
     <PanelContent className="items-start justify-start">
+      <BackButton />
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"

--- a/src/pages/Reach.jsx
+++ b/src/pages/Reach.jsx
@@ -1,15 +1,32 @@
 import PanelContent from "../components/PanelContent";
+import BackButton from "../components/BackButton";
 import { motion } from "framer-motion";
 
 export default function Reach() {
   const socials = [
-    { id: 1, href: "#", img: "https://via.placeholder.com/150", alt: "Social 1" },
-    { id: 2, href: "#", img: "https://via.placeholder.com/150", alt: "Social 2" },
-    { id: 3, href: "#", img: "https://via.placeholder.com/150", alt: "Social 3" },
+    {
+      id: 1,
+      href: "#",
+      img: "https://via.placeholder.com/150",
+      alt: "Social 1",
+    },
+    {
+      id: 2,
+      href: "#",
+      img: "https://via.placeholder.com/150",
+      alt: "Social 2",
+    },
+    {
+      id: 3,
+      href: "#",
+      img: "https://via.placeholder.com/150",
+      alt: "Social 3",
+    },
   ];
 
   return (
     <PanelContent className="items-start justify-start">
+      <BackButton />
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import PanelContent from "../components/PanelContent";
+import BackButton from "../components/BackButton";
 import IssueCarousel from "../components/IssueCarousel";
 import IssueInfoPanel from "../components/IssueInfoPanel";
 
@@ -13,6 +14,7 @@ export default function Read() {
 
   return (
     <PanelContent className="items-start justify-start">
+      <BackButton />
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -1,9 +1,11 @@
 import PanelContent from "../components/PanelContent";
+import BackButton from "../components/BackButton";
 import { motion } from "framer-motion";
 
 export default function World() {
   return (
     <PanelContent className="items-start justify-start">
+      <BackButton />
       <motion.section
         className="flex items-center justify-center hero-full"
         initial={{ opacity: 0, y: -20 }}


### PR DESCRIPTION
## Summary
- remove BackButton from the main App layout
- import and render BackButton within each subpage component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2117bf2208321a24d91fcb92796f5