### PR TITLE
Add back button to page headers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import { Suspense, lazy } from "react";
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { LayoutGroup } from "framer-motion";
-import BackButton from "./components/BackButton";
 
 const PanelGrid = lazy(() => import("./components/PanelGrid"));
 const Read = lazy(() => import("./pages/Read"));
@@ -30,7 +29,6 @@ export default function App() {
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </Suspense>
-        <BackButton />
       </LayoutGroup>
     </div>
   );

--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -10,10 +10,8 @@ export default function BackButton() {
     return null;
   }
 
-  const positionClasses = "top-4 left-4";
-  const baseClasses =
-    "absolute w-12 h-12 rounded-full border overflow-hidden transition-colors duration-200";
-  const className = `${baseClasses} ${positionClasses}`;
+  const className =
+    "w-12 h-12 rounded-full border overflow-hidden transition-colors duration-200";
 
   return (
     <motion.button

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,5 +1,6 @@
 import PanelContent from "../components/PanelContent";
 import { motion } from "framer-motion";
+import BackButton from "../components/BackButton";
 
 export default function Buy() {
   return (
@@ -10,12 +11,15 @@ export default function Buy() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <motion.h1
-          layoutId="BUY"
-          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-        >
-          BUY
-        </motion.h1>
+        <div className="flex items-center gap-4">
+          <BackButton />
+          <motion.h1
+            layoutId="BUY"
+            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          >
+            BUY
+          </motion.h1>
+        </div>
         <motion.p
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import PanelContent from "../components/PanelContent";
 import TeamCarousel from "../components/TeamCarousel";
 import TeamInfoPanel from "../components/TeamInfoPanel";
+import BackButton from "../components/BackButton";
 
 export default function Meet() {
   const [selectedMemberId, setSelectedMemberId] = useState(null);
@@ -22,12 +23,15 @@ export default function Meet() {
       >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
-            <motion.h1
-              layoutId="MEET"
-              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-            >
-              MEET
-            </motion.h1>
+            <div className="flex items-center gap-4">
+              <BackButton />
+              <motion.h1
+                layoutId="MEET"
+                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              >
+                MEET
+              </motion.h1>
+            </div>
             <motion.p
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0 }}

--- a/src/pages/Reach.jsx
+++ b/src/pages/Reach.jsx
@@ -1,5 +1,6 @@
 import PanelContent from "../components/PanelContent";
 import { motion } from "framer-motion";
+import BackButton from "../components/BackButton";
 
 export default function Reach() {
   const socials = [
@@ -18,12 +19,15 @@ export default function Reach() {
         transition={{ duration: 0.5 }}
       >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center gap-4">
-          <motion.h1
-            layoutId="REACH"
-            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-          >
-            REACH
-          </motion.h1>
+          <div className="flex items-center gap-4">
+            <BackButton />
+            <motion.h1
+              layoutId="REACH"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            >
+              REACH
+            </motion.h1>
+          </div>
           <motion.p
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import PanelContent from "../components/PanelContent";
 import IssueCarousel from "../components/IssueCarousel";
 import IssueInfoPanel from "../components/IssueInfoPanel";
+import BackButton from "../components/BackButton";
 
 export default function Read() {
   const [selectedIssueId, setSelectedIssueId] = useState(null);
@@ -22,12 +23,15 @@ export default function Read() {
       >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
-            <motion.h1
-              layoutId="READ"
-              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-            >
-              READ
-            </motion.h1>
+            <div className="flex items-center gap-4">
+              <BackButton />
+              <motion.h1
+                layoutId="READ"
+                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              >
+                READ
+              </motion.h1>
+            </div>
             <motion.p
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0 }}

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -1,5 +1,6 @@
 import PanelContent from "../components/PanelContent";
 import { motion } from "framer-motion";
+import BackButton from "../components/BackButton";
 
 export default function World() {
   return (
@@ -10,12 +11,15 @@ export default function World() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <motion.h1
-          layoutId="EXPLORE"
-          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-        >
-          EXPLORE
-        </motion.h1>
+        <div className="flex items-center gap-4">
+          <BackButton />
+          <motion.h1
+            layoutId="EXPLORE"
+            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          >
+            EXPLORE
+          </motion.h1>
+        </div>
       </motion.section>
     </PanelContent>
   );


### PR DESCRIPTION
## Summary
- Show BackButton component next to each subpage title
- Remove global BackButton and make it inline for new layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a21180ab208321be9a37f483312e93