### PR TITLE
Remove duplicated BackButton instances

### DIFF
--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -12,15 +12,12 @@ export default function Buy() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <div className="flex items-center gap-4">
-          <BackButton />
-          <motion.h1
-            layoutId="BUY"
-            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-          >
-            BUY
-          </motion.h1>
-        </div>
+        <motion.h1
+          layoutId="BUY"
+          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+        >
+          BUY
+        </motion.h1>
         <motion.p
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -24,15 +24,12 @@ export default function Meet() {
       >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
-            <div className="flex items-center gap-4">
-              <BackButton />
-              <motion.h1
-                layoutId="MEET"
-                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-              >
-                MEET
-              </motion.h1>
-            </div>
+            <motion.h1
+              layoutId="MEET"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            >
+              MEET
+            </motion.h1>
             <motion.p
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0 }}

--- a/src/pages/Reach.jsx
+++ b/src/pages/Reach.jsx
@@ -35,15 +35,12 @@ export default function Reach() {
         transition={{ duration: 0.5 }}
       >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center gap-4">
-          <div className="flex items-center gap-4">
-            <BackButton />
-            <motion.h1
-              layoutId="REACH"
-              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-            >
-              REACH
-            </motion.h1>
-          </div>
+          <motion.h1
+            layoutId="REACH"
+            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          >
+            REACH
+          </motion.h1>
           <motion.p
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -24,15 +24,12 @@ export default function Read() {
       >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
           <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
-            <div className="flex items-center gap-4">
-              <BackButton />
-              <motion.h1
-                layoutId="READ"
-                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-              >
-                READ
-              </motion.h1>
-            </div>
+            <motion.h1
+              layoutId="READ"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            >
+              READ
+            </motion.h1>
             <motion.p
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0 }}

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -12,15 +12,12 @@ export default function World() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <div className="flex items-center gap-4">
-          <BackButton />
-          <motion.h1
-            layoutId="EXPLORE"
-            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-          >
-            EXPLORE
-          </motion.h1>
-        </div>
+        <motion.h1
+          layoutId="EXPLORE"
+          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+        >
+          EXPLORE
+        </motion.h1>
       </motion.section>
     </PanelContent>
   );


### PR DESCRIPTION
## Summary
- render only a single `BackButton` on Buy, World, Read, Meet, and Reach pages
- clean up hero layout on each page to avoid duplicate button renders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d5dea7c8321a60910e873bf512a