### PR TITLE
Remove duplicated BackButton instances

### DIFF
--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -5,7 +5,6 @@ import { motion } from "framer-motion";
 export default function Buy() {
   return (
     <PanelContent className="items-start justify-start">
-      <BackButton />
       <motion.section
         className="flex flex-col items-center justify-center p-4 text-center gap-4 hero-full"
         initial={{ opacity: 0, y: -20 }}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -14,7 +14,6 @@ export default function Meet() {
 
   return (
     <PanelContent className="items-start justify-start">
-      <BackButton />
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"

--- a/src/pages/Reach.jsx
+++ b/src/pages/Reach.jsx
@@ -26,7 +26,6 @@ export default function Reach() {
 
   return (
     <PanelContent className="items-start justify-start">
-      <BackButton />
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -14,7 +14,6 @@ export default function Read() {
 
   return (
     <PanelContent className="items-start justify-start">
-      <BackButton />
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -5,7 +5,6 @@ import { motion } from "framer-motion";
 export default function World() {
   return (
     <PanelContent className="items-start justify-start">
-      <BackButton />
       <motion.section
         className="flex items-center justify-center hero-full"
         initial={{ opacity: 0, y: -20 }}


### PR DESCRIPTION
## Summary
- render a single `BackButton` next to the panel labels on Buy, World, Read, Meet, and Reach pages
- remove the redundant button above each hero section to keep transitions consistent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d5dea7c8321a60910e873bf512a