### PR TITLE
Center hero sections and add back buttons

### DIFF
--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -4,24 +4,27 @@ import { motion } from "framer-motion";
 
 export default function Buy() {
   return (
-    <PanelContent className="items-start justify-start">
+    <PanelContent>
       <motion.section
-        className="flex flex-col items-center justify-center p-4 text-center gap-4 hero-full"
+        className="flex flex-col items-center justify-center gap-4 p-4 text-center hero-full"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <motion.h1
-          layoutId="BUY"
-          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-        >
-          BUY
-        </motion.h1>
+        <div className="flex items-center gap-4">
+          <BackButton />
+          <motion.h1
+            layoutId="BUY"
+            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          >
+            BUY
+          </motion.h1>
+        </div>
         <motion.p
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.2 }}
-          className="text-lg md:text-2xl max-w-xl"
+          className="max-w-xl text-lg md:text-2xl"
         >
           Support Renowned Home by backing our upcoming Kickstarter campaign.
         </motion.p>
@@ -30,7 +33,7 @@ export default function Buy() {
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.4 }}
-          className="mt-4 px-8 py-3 font-bold uppercase bg-black text-white rounded"
+          className="mt-4 rounded bg-black px-8 py-3 font-bold uppercase text-white"
         >
           KICKSTARTER
         </motion.a>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -13,7 +13,7 @@ export default function Meet() {
   };
 
   return (
-    <PanelContent className="items-start justify-start">
+    <PanelContent>
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"
@@ -22,18 +22,21 @@ export default function Meet() {
         transition={{ duration: 0.5 }}
       >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
-          <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
-            <motion.h1
-              layoutId="MEET"
-              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-            >
-              MEET
-            </motion.h1>
+          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
+            <div className="flex items-center gap-4">
+              <BackButton />
+              <motion.h1
+                layoutId="MEET"
+                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              >
+                MEET
+              </motion.h1>
+            </div>
             <motion.p
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.2 }}
-              className="text-lg md:text-2xl max-w-xl text-center"
+              className="max-w-xl text-lg md:text-2xl"
             >
               Learn about the team behind Renowned Home.
             </motion.p>

--- a/src/pages/Reach.jsx
+++ b/src/pages/Reach.jsx
@@ -25,7 +25,7 @@ export default function Reach() {
   ];
 
   return (
-    <PanelContent className="items-start justify-start">
+    <PanelContent>
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"
@@ -33,18 +33,21 @@ export default function Reach() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center gap-4">
-          <motion.h1
-            layoutId="REACH"
-            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-          >
-            REACH
-          </motion.h1>
+        <div className="relative flex flex-col items-center justify-center w-full h-full gap-4 p-4 text-center">
+          <div className="flex items-center gap-4">
+            <BackButton />
+            <motion.h1
+              layoutId="REACH"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            >
+              REACH
+            </motion.h1>
+          </div>
           <motion.p
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.2 }}
-            className="text-lg md:text-2xl max-w-xl"
+            className="max-w-xl text-lg md:text-2xl"
           >
             Stay connected with Renowned Home.
           </motion.p>
@@ -58,12 +61,12 @@ export default function Reach() {
             <input
               type="email"
               placeholder="Enter your email"
-              className="flex-grow p-2 border rounded-l bg-[var(--background)] text-[var(--foreground)]"
+              className="flex-grow rounded-l border p-2 bg-[var(--background)] text-[var(--foreground)]"
               style={{ borderColor: "var(--border)" }}
             />
             <button
               type="submit"
-              className="p-2 border rounded-r bg-[var(--accent)] text-white"
+              className="rounded-r border p-2 bg-[var(--accent)] text-white"
               style={{ borderColor: "var(--border)" }}
             >
               Submit

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -13,7 +13,7 @@ export default function Read() {
   };
 
   return (
-    <PanelContent className="items-start justify-start">
+    <PanelContent>
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"
@@ -22,18 +22,21 @@ export default function Read() {
         transition={{ duration: 0.5 }}
       >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
-          <div className="flex flex-col md:flex-row items-center justify-center w-full gap-4 md:gap-8">
-            <motion.h1
-              layoutId="READ"
-              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-            >
-              READ
-            </motion.h1>
+          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
+            <div className="flex items-center gap-4">
+              <BackButton />
+              <motion.h1
+                layoutId="READ"
+                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              >
+                READ
+              </motion.h1>
+            </div>
             <motion.p
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.2 }}
-              className="text-lg md:text-2xl max-w-xl text-center"
+              className="max-w-xl text-lg md:text-2xl"
             >
               Explore the latest issue of Renowned Home.
             </motion.p>

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -4,19 +4,22 @@ import { motion } from "framer-motion";
 
 export default function World() {
   return (
-    <PanelContent className="items-start justify-start">
+    <PanelContent>
       <motion.section
         className="flex items-center justify-center hero-full"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <motion.h1
-          layoutId="EXPLORE"
-          className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-        >
-          EXPLORE
-        </motion.h1>
+        <div className="flex items-center gap-4">
+          <BackButton />
+          <motion.h1
+            layoutId="EXPLORE"
+            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          >
+            EXPLORE
+          </motion.h1>
+        </div>
       </motion.section>
     </PanelContent>
   );


### PR DESCRIPTION
## Summary
- Remove custom alignment overrides so PanelContent centers page heroes by default
- Wrap BackButton and titles in a flex container across Buy, World, Read, Meet, and Reach pages
- Ensure hero content remains centered and back button aligns directly beside titles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run build` (fails: Could not resolve entry module "index.html")

------
https://chatgpt.com/codex/tasks/task_e_68a27250878483218b363e86019b72c4