### PR TITLE
refactor: preload subpages for initial navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,12 @@
-import { Suspense, lazy } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { LayoutGroup } from "framer-motion";
 
-const PanelGrid = lazy(() => import("./components/PanelGrid"));
-const Read = lazy(() => import("./pages/Read"));
-const Buy = lazy(() => import("./pages/Buy"));
-const World = lazy(() => import("./pages/World"));
-const Meet = lazy(() => import("./pages/Meet"));
-const Reach = lazy(() => import("./pages/Reach"));
+import PanelGrid from "./components/PanelGrid";
+import Read from "./pages/Read";
+import Buy from "./pages/Buy";
+import World from "./pages/World";
+import Meet from "./pages/Meet";
+import Reach from "./pages/Reach";
 
 export default function App() {
   return (
@@ -16,17 +15,15 @@ export default function App() {
       style={{ borderColor: "var(--border)" }}
     >
       <LayoutGroup>
-        <Suspense fallback={<div>Loading...</div>}>
-          <Routes>
-            <Route path="/" element={<PanelGrid />} />
-            <Route path="/read" element={<Read />} />
-            <Route path="/buy" element={<Buy />} />
-            <Route path="/world" element={<World />} />
-            <Route path="/meet" element={<Meet />} />
-            <Route path="/reach" element={<Reach />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-        </Suspense>
+        <Routes>
+          <Route path="/" element={<PanelGrid />} />
+          <Route path="/read" element={<Read />} />
+          <Route path="/buy" element={<Buy />} />
+          <Route path="/world" element={<World />} />
+          <Route path="/meet" element={<Meet />} />
+          <Route path="/reach" element={<Reach />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
       </LayoutGroup>
     </div>
   );


### PR DESCRIPTION
## Summary
- statically import all subpages at startup
- remove Suspense wrapper so target routes mount immediately

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2725cac688321bbe348f4d3f0357b