### PR TITLE
chore: add placeholder WordPress credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Example environment variables. Copy to .env and replace placeholders with real credentials.
+# Never commit real secrets to version control.
 VITE_WP_BASE_URL=https://renownedcomic.com/wp-admin/
-VITE_WP_USERNAME=root
-VITE_WP_APP_PASSWORD=cFrZZDSuPC2k@JGF@X5NG&kd
+VITE_WP_USERNAME=your_username
+VITE_WP_APP_PASSWORD=your_app_password


### PR DESCRIPTION
## Summary
- replace WordPress username and app password in `.env.example` with placeholders
- document that real secrets belong in a private `.env`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a28c27bd8c83218a9180923fd5c216