### PR TITLE
Align half-hero pages with top spacing

### DIFF
--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -13,7 +13,7 @@ export default function Meet() {
   };
 
   return (
-    <PanelContent>
+    <PanelContent className="justify-start">
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"

--- a/src/pages/Reach.jsx
+++ b/src/pages/Reach.jsx
@@ -24,8 +24,8 @@ export default function Reach() {
     },
   ];
 
-  return (
-    <PanelContent>
+    return (
+      <PanelContent className="justify-start">
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -13,7 +13,7 @@ export default function Read() {
   };
 
   return (
-    <PanelContent>
+    <PanelContent className="justify-start">
       {/* Hero Section */}
       <motion.section
         className="relative flex-shrink-0 hero-half"


### PR DESCRIPTION
## Summary
- Align half-hero pages (Read, Meet, Reach) to the top by passing `justify-start` to PanelContent
- Reduces extra whitespace to match full hero layout

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a510581c488321807110bc32540c6b