### PR TITLE
refactor: move home button to top right

### DIFF
--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -9,25 +9,25 @@ const connectImg = "/panels/connect.jpg";
 
 export default function PanelGrid() {
   return (
-    <div className="grid grid-rows-3 gap-4 w-full h-full">
-      <div className="relative grid h-full grid-cols-1 gap-4">
+    <div className="relative grid grid-rows-3 gap-4 w-full h-full">
+      <motion.div
+        layoutId="back-button"
+        className="absolute top-4 right-4 w-12 h-12 rounded-full border bg-white flex items-center justify-center overflow-hidden"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <ImageWithFallback
+          src="/logo.png"
+          alt="Logo"
+          className="w-full h-full object-contain"
+        />
+      </motion.div>
+      <div className="grid h-full grid-cols-1 gap-4">
         <PanelCard
           className="bg-white h-full"
           imageSrc={worldImg || undefined}
           label="EXPLORE"
           to="/world"
         />
-        <motion.div
-          layoutId="back-button"
-          className="absolute top-4 right-4 w-12 h-12 rounded-full border bg-white flex items-center justify-center overflow-hidden"
-          style={{ borderColor: "var(--border)" }}
-        >
-          <ImageWithFallback
-            src="/logo.png"
-            alt="Logo"
-            className="w-full h-full object-contain"
-          />
-        </motion.div>
       </div>
       <div className="grid h-full grid-cols-2 gap-4">
         <PanelCard


### PR DESCRIPTION
## Summary
- move home page logo button to the top right

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a512e8a0648321ae9a7abe11f655fb