### PR TITLE
Expose panel labels above all content

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -10,7 +10,7 @@ export default function PanelCard({
 }) {
   const content = (
     <div
-      className={`relative w-full h-full overflow-hidden cursor-pointer group border bg-[var(--background)] ${className}`}
+      className={`relative w-full h-full cursor-pointer group border bg-[var(--background)] ${className}`}
       style={{ borderColor: "var(--border)" }}
     >
       {imageSrc && (
@@ -22,10 +22,10 @@ export default function PanelCard({
       )}
       <div className="absolute inset-0 bg-black opacity-0 transition-opacity duration-300 group-hover:opacity-20 pointer-events-none" />
       {label && (
-        <div className="absolute inset-0 flex items-center justify-center">
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-[9999]">
           <motion.span
             layoutId={label}
-            className="relative z-50 text-white font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
+            className="text-white font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}
           </motion.span>


### PR DESCRIPTION
## Summary
- Remove panel card overflow clipping to let labels escape their panels
- Elevate label layer with a very high z-index so labels remain visible across the app

## Testing
- ⚠️ `npm test` (missing script: test)
- ⚠️ `npm run lint` (ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68a5134cd68c8321ab446c9239b0ba00