### PR TITLE
Align hero sections to top

### DIFF
--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -33,7 +33,7 @@ export default function Connect() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <div className="relative flex flex-col items-center justify-center w-full h-full gap-4 p-4 text-center">
+        <div className="relative flex flex-col items-center justify-start w-full h-full gap-4 p-4 text-center">
           <div className="flex items-center gap-4">
             <BackButton />
             <motion.h1

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -21,8 +21,8 @@ export default function Meet() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
-          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
+        <div className="relative flex flex-col items-center justify-start w-full h-full p-4 text-center">
+          <div className="flex flex-col items-center justify-start w-full gap-4 md:gap-8">
             <div className="flex items-center gap-4">
               <BackButton />
               <motion.h1

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -21,8 +21,8 @@ export default function Read() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
-          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
+        <div className="relative flex flex-col items-center justify-start w-full h-full p-4 text-center">
+          <div className="flex flex-col items-center justify-start w-full gap-4 md:gap-8">
             <div className="flex items-center gap-4">
               <BackButton />
               <motion.h1


### PR DESCRIPTION
## Summary
- adjust hero containers in Read, Meet, and Connect pages to use `justify-start` for top alignment

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*


------
https://chatgpt.com/codex/tasks/task_e_68a5163be8b88321ba7574b29ae32c39