### PR TITLE
Align hero sections to top

### DIFF
--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -4,9 +4,9 @@ import { motion } from "framer-motion";
 
 export default function Buy() {
   return (
-    <PanelContent>
+    <PanelContent className="justify-start">
       <motion.section
-        className="flex flex-col items-center justify-center gap-4 p-4 text-center hero-full"
+        className="flex flex-col items-center justify-start gap-4 p-4 text-center hero-full"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -4,9 +4,9 @@ import { motion } from "framer-motion";
 
 export default function World() {
   return (
-    <PanelContent>
+    <PanelContent className="justify-start">
       <motion.section
-        className="flex items-center justify-center hero-full"
+        className="flex items-center justify-start hero-full"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}


### PR DESCRIPTION
## Summary
- Adjust Buy and World hero sections to use justify-start, keeping content at the top
- Apply top alignment to PanelContent wrappers on Buy and World pages for consistent hero placement

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5182f919c83218bceef9cf42956d7