### PR TITLE
Start hero backgrounds at top and center content

### DIFF
--- a/src/components/PanelContent.jsx
+++ b/src/components/PanelContent.jsx
@@ -1,6 +1,6 @@
 export default function PanelContent({ children, className = "" }) {
   return (
-    <div className={`flex flex-col items-center justify-center w-full h-full ${className}`}>
+    <div className={`flex flex-col items-center justify-start w-full h-full ${className}`}>
       {children}
     </div>
   );

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -6,7 +6,7 @@ export default function Buy() {
   return (
     <PanelContent className="justify-start">
       <motion.section
-        className="flex flex-col items-center justify-start gap-4 p-4 text-center hero-full"
+        className="flex flex-col items-center justify-center gap-4 p-4 text-center hero-full"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -33,7 +33,7 @@ export default function Connect() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <div className="relative flex flex-col items-center justify-start w-full h-full gap-4 p-4 text-center">
+        <div className="relative flex flex-col items-center justify-center w-full h-full gap-4 p-4 text-center">
           <div className="flex items-center gap-4">
             <BackButton />
             <motion.h1

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -21,8 +21,8 @@ export default function Meet() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <div className="relative flex flex-col items-center justify-start w-full h-full p-4 text-center">
-          <div className="flex flex-col items-center justify-start w-full gap-4 md:gap-8">
+        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
+          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
             <div className="flex items-center gap-4">
               <BackButton />
               <motion.h1

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -21,8 +21,8 @@ export default function Read() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        <div className="relative flex flex-col items-center justify-start w-full h-full p-4 text-center">
-          <div className="flex flex-col items-center justify-start w-full gap-4 md:gap-8">
+        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
+          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
             <div className="flex items-center gap-4">
               <BackButton />
               <motion.h1

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -6,7 +6,7 @@ export default function World() {
   return (
     <PanelContent className="justify-start">
       <motion.section
-        className="flex items-center justify-start hero-full"
+        className="flex items-center justify-center hero-full"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}


### PR DESCRIPTION
## Summary
- Anchor PanelContent to the top by default so hero backgrounds begin at the page top
- Center hero section content across pages for consistent layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a519f459f883218de1f02bdde4686c