### PR TITLE
Load issues from WordPress for IssueCarousel

### DIFF
--- a/src/api/wordpress.js
+++ b/src/api/wordpress.js
@@ -22,6 +22,18 @@ export async function fetchMedia() {
   return res.json();
 }
 
+export async function fetchIssues() {
+  const res = await fetch(`${baseUrl}/wp-json/wp/v2/issues?_embed`, {
+    headers: {
+      ...authHeader(),
+    },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch issues');
+  }
+  return res.json();
+}
+
 export async function uploadMedia(file) {
   const formData = new FormData();
   formData.append('file', file);

--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -1,8 +1,8 @@
-import useWordPressMedia from "../hooks/useWordPressMedia";
+import useWordPressIssues from "../hooks/useWordPressIssues";
 import ImageWithFallback from "./ImageWithFallback";
 
 export default function IssueCarousel({ selectedId, onSelect }) {
-  const { media, loading, error } = useWordPressMedia();
+  const { issues: issuePosts, loading, error } = useWordPressIssues();
 
   if (loading) {
     return <div>Loading...</div>;
@@ -12,11 +12,13 @@ export default function IssueCarousel({ selectedId, onSelect }) {
     return <div>Error loading media.</div>;
   }
 
-  const issues = media.map((m) => ({
-    id: m.id,
-    title: m.title?.rendered || "Untitled",
-    previewImage: m.media_details?.sizes?.medium?.source_url || m.source_url,
-    coverImage: m.source_url,
+  const issues = issuePosts.map((issue) => ({
+    id: issue.id,
+    title: issue.title.rendered,
+    coverImage: issue.acf.cover_image,
+    releaseDate: issue.acf.release_date,
+    shortDescription: issue.acf.short_description,
+    longDescription: issue.acf.long_description,
   }));
 
   return (
@@ -32,7 +34,7 @@ export default function IssueCarousel({ selectedId, onSelect }) {
             style={{ borderColor: "var(--border)" }}
           >
             <ImageWithFallback
-              src={issue.previewImage}
+              src={issue.coverImage}
               alt={issue.title}
               className="w-full h-40 object-cover"
             />

--- a/src/hooks/useWordPressIssues.js
+++ b/src/hooks/useWordPressIssues.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { fetchIssues } from '../api/wordpress';
+
+export default function useWordPressIssues() {
+  const [issues, setIssues] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchIssues();
+      setIssues(data);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return { issues, loading, error, refresh: load };
+}
+


### PR DESCRIPTION
## Summary
- add `fetchIssues` API to load WordPress issues
- create `useWordPressIssues` hook for fetching and refreshing issues
- update `IssueCarousel` to display issue cover images and titles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a527a3a0608321995e491b76f0a03c