### PR TITLE
feat: log WordPress and ACF data requests

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -17,7 +17,20 @@ add_action( 'init', function() {
 add_action( 'rest_api_init', function() {
     register_rest_field( 'issues', 'acf', [
         'get_callback' => function( $object ) {
-            return get_fields( $object['id'] );
+            $post_id = $object['id'];
+            error_log( "ACF: fetching fields for post {$post_id}" );
+            try {
+                $fields = get_fields( $post_id );
+                if ( false === $fields ) {
+                    error_log( "ACF: failed to fetch fields for post {$post_id}" );
+                    return null;
+                }
+                error_log( "ACF: fetched fields for post {$post_id}" );
+                return $fields;
+            } catch ( \Throwable $e ) {
+                error_log( "ACF: error fetching fields for post {$post_id}: " . $e->getMessage() );
+                return null;
+            }
         },
         'schema' => null,
     ] );

--- a/src/api/wordpress.js
+++ b/src/api/wordpress.js
@@ -1,3 +1,5 @@
+import { logRequest, logSuccess, logError } from '../utils/logger';
+
 const baseUrl = import.meta.env.VITE_WP_BASE_URL;
 const username = import.meta.env.VITE_WP_USERNAME;
 const password = import.meta.env.VITE_WP_APP_PASSWORD;
@@ -11,44 +13,74 @@ function authHeader() {
 }
 
 export async function fetchMedia() {
-  const res = await fetch(`${baseUrl}/wp-json/wp/v2/media`, {
-    headers: {
-      ...authHeader(),
-    },
-  });
-  if (!res.ok) {
-    throw new Error('Failed to fetch media');
+  const endpoint = `${baseUrl}/wp-json/wp/v2/media`;
+  logRequest('Fetching media', endpoint);
+  try {
+    const res = await fetch(endpoint, {
+      headers: {
+        ...authHeader(),
+      },
+    });
+    if (!res.ok) {
+      logError('Failed to fetch media', `${res.status} ${res.statusText}`);
+      throw new Error('Failed to fetch media');
+    }
+    const data = await res.json();
+    logSuccess('Fetched media', { count: data.length });
+    return data;
+  } catch (err) {
+    logError('Error fetching media', err);
+    throw err;
   }
-  return res.json();
 }
 
 export async function fetchIssues() {
-  const res = await fetch(`${baseUrl}/wp-json/wp/v2/issues?_embed`, {
-    headers: {
-      ...authHeader(),
-    },
-  });
-  if (!res.ok) {
-    throw new Error('Failed to fetch issues');
+  const endpoint = `${baseUrl}/wp-json/wp/v2/issues?_embed`;
+  logRequest('Fetching issues with ACF fields', endpoint);
+  try {
+    const res = await fetch(endpoint, {
+      headers: {
+        ...authHeader(),
+      },
+    });
+    if (!res.ok) {
+      logError('Failed to fetch issues', `${res.status} ${res.statusText}`);
+      throw new Error('Failed to fetch issues');
+    }
+    const data = await res.json();
+    logSuccess('Fetched issues with ACF fields', { count: data.length });
+    return data;
+  } catch (err) {
+    logError('Error fetching issues', err);
+    throw err;
   }
-  return res.json();
 }
 
 export async function uploadMedia(file) {
   const formData = new FormData();
   formData.append('file', file);
+  const endpoint = `${baseUrl}/wp-json/wp/v2/media`;
+  logRequest('Uploading media', { name: file?.name });
 
-  const res = await fetch(`${baseUrl}/wp-json/wp/v2/media`, {
-    method: 'POST',
-    headers: {
-      ...authHeader(),
-    },
-    body: formData,
-  });
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        ...authHeader(),
+      },
+      body: formData,
+    });
 
-  if (!res.ok) {
-    throw new Error('Failed to upload media');
+    if (!res.ok) {
+      logError('Failed to upload media', `${res.status} ${res.statusText}`);
+      throw new Error('Failed to upload media');
+    }
+    const data = await res.json();
+    logSuccess('Uploaded media', data);
+    return data;
+  } catch (err) {
+    logError('Error uploading media', err);
+    throw err;
   }
-  return res.json();
 }
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,13 @@
+const prefix = '[WP API]';
+
+export function logRequest(message, info) {
+  console.info(`${prefix} ${message}`, info);
+}
+
+export function logSuccess(message, info) {
+  console.info(`${prefix} Success: ${message}`, info);
+}
+
+export function logError(message, error) {
+  console.error(`${prefix} Error: ${message}`, error);
+}


### PR DESCRIPTION
## Summary
- add centralized logger utility
- log WordPress media and issues requests and uploads
- log ACF field retrieval failures on the server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a52dc1e07c832187d8e2dc34db69d5