### PR TITLE
Refactor IssueInfoPanel to use WordPress issue data

### DIFF
--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -1,13 +1,18 @@
 import { motion } from "framer-motion";
-import issues from "../data/issues";
 import ImageWithFallback from "./ImageWithFallback";
 
-export default function IssueInfoPanel({ issueId }) {
-  const issue = issues.find((i) => i.id === issueId);
-
+export default function IssueInfoPanel({ issue }) {
   if (!issue) {
     return null;
   }
+
+  const title = issue.title?.rendered || issue.title;
+  const {
+    cover_image: coverImage,
+    subtitle,
+    long_description: description,
+    credits,
+  } = issue.acf || {};
 
   return (
     <motion.div
@@ -18,24 +23,24 @@ export default function IssueInfoPanel({ issueId }) {
       className="flex flex-col items-center gap-4 p-4 mt-4 border rounded bg-[var(--background)]"
       style={{ borderColor: "var(--border)" }}
     >
-      {issue.coverImage && (
+      {coverImage && (
         <ImageWithFallback
-          src={issue.coverImage}
-          alt={issue.title}
+          src={coverImage}
+          alt={title}
           className="w-full max-w-sm rounded"
         />
       )}
       <div className="text-center">
-        <h2 className="text-2xl font-bold">{issue.title}</h2>
-        {issue.subtitle && (
-          <h3 className="text-lg text-gray-500">{issue.subtitle}</h3>
+        <h2 className="text-2xl font-bold">{title}</h2>
+        {subtitle && (
+          <h3 className="text-lg text-gray-500">{subtitle}</h3>
         )}
       </div>
-      {issue.description && (
-        <p className="max-w-xl text-center">{issue.description}</p>
+      {description && (
+        <p className="max-w-xl text-center">{description}</p>
       )}
-      {issue.credits && (
-        <p className="text-sm text-gray-500 text-center">{issue.credits}</p>
+      {credits && (
+        <p className="text-sm text-gray-500 text-center">{credits}</p>
       )}
     </motion.div>
   );

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -4,12 +4,15 @@ import PanelContent from "../components/PanelContent";
 import IssueCarousel from "../components/IssueCarousel";
 import IssueInfoPanel from "../components/IssueInfoPanel";
 import BackButton from "../components/BackButton";
+import useWordPressIssues from "../hooks/useWordPressIssues";
 
 export default function Read() {
-  const [selectedIssueId, setSelectedIssueId] = useState(null);
+  const { issues } = useWordPressIssues();
+  const [selectedIssue, setSelectedIssue] = useState(null);
 
   const handleSelect = (id) => {
-    setSelectedIssueId((prev) => (prev === id ? null : id));
+    const issue = issues.find((i) => i.id === id);
+    setSelectedIssue((prev) => (prev?.id === id ? null : issue));
   };
 
   return (
@@ -51,10 +54,10 @@ export default function Read() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, delay: 0.4 }}
       >
-        <IssueCarousel selectedId={selectedIssueId} onSelect={handleSelect} />
+        <IssueCarousel selectedId={selectedIssue?.id} onSelect={handleSelect} />
         <AnimatePresence mode="wait">
-          {selectedIssueId && (
-            <IssueInfoPanel issueId={selectedIssueId} key={selectedIssueId} />
+          {selectedIssue && (
+            <IssueInfoPanel issue={selectedIssue} key={selectedIssue.id} />
           )}
         </AnimatePresence>
       </motion.div>


### PR DESCRIPTION
## Summary
- Refactor IssueInfoPanel to accept a full WordPress issue object and drop local data dependency
- Fetch issues in Read page and pass selected issue object to IssueInfoPanel
- Toggle info panel when clicking the same issue twice

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68a5425aba548321b96e4bbbd21e7404