### PR TITLE
Allow larger issue cover images

### DIFF
--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -27,7 +27,7 @@ export default function IssueInfoPanel({ issue }) {
         <ImageWithFallback
           src={coverImage}
           alt={title}
-          className="w-full max-w-sm rounded"
+          className="w-full rounded"
         />
       )}
       <div className="text-center">


### PR DESCRIPTION
## Summary
- remove max width restriction on issue cover images to allow larger dimensions and remain responsive

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint configuration not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5457f65c48321b74ca60d6c37539d