### PR TITLE
Order issues by ACF number

### DIFF
--- a/src/hooks/useWordPressIssues.js
+++ b/src/hooks/useWordPressIssues.js
@@ -11,7 +11,14 @@ export default function useWordPressIssues() {
     setError(null);
     try {
       const data = await fetchIssues();
-      setIssues(data);
+      const sorted = [...data].sort((a, b) => {
+        const aNum = Number(a.acf?.number);
+        const bNum = Number(b.acf?.number);
+        const aVal = Number.isFinite(aNum) ? aNum : Infinity;
+        const bVal = Number.isFinite(bNum) ? bNum : Infinity;
+        return aVal - bVal;
+      });
+      setIssues(sorted);
     } catch (err) {
       setError(err);
     } finally {


### PR DESCRIPTION
## Summary
- sort issues from WordPress by their ACF `number` field so the Read page reflects this ordering

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a92be69bc4832198c09ddc260f2557