### PR TITLE
Handle cover image arrays and ensure URL string

### DIFF
--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -13,12 +13,18 @@ export default function IssueCarousel({ selectedId, onSelect }) {
   }
 
   const issues = issuePosts.map((issue) => {
-    const rawCover = issue.acf?.cover_image?.url || issue.acf?.cover_image;
-    const coverImage =
-      typeof rawCover === "number" ||
-      (typeof rawCover === "string" && /^\d+$/.test(rawCover))
+    const rawCoverField = issue.acf?.cover_image;
+    const rawCover = Array.isArray(rawCoverField)
+      ? rawCoverField[0]?.url || rawCoverField[0]
+      : rawCoverField?.url || rawCoverField;
+    const coverImageCandidate =
+      !Array.isArray(rawCoverField) &&
+      (typeof rawCover === "number" ||
+        (typeof rawCover === "string" && /^\d+$/.test(rawCover)))
         ? issue._embedded?.["wp:featuredmedia"]?.[0]?.source_url
         : rawCover || issue._embedded?.["wp:featuredmedia"]?.[0]?.source_url;
+    const coverImage =
+      typeof coverImageCandidate === "string" ? coverImageCandidate : "";
 
     return {
       id: issue.id,


### PR DESCRIPTION
## Summary
- handle `acf.cover_image` arrays by grabbing the first entry's URL
- keep numeric ID fallback only for single values
- ensure cover image passed to `ImageWithFallback` is always a string

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9329693208321bc46199f406ab63a