### PR TITLE
Fix cover image handling

### DIFF
--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -8,11 +8,19 @@ export default function IssueInfoPanel({ issue }) {
 
   const title = issue.title?.rendered || issue.title;
   const {
-    cover_image: coverImage,
+    cover_image,
     subtitle,
     long_description: description,
     credits,
   } = issue.acf || {};
+
+  const coverImage = Array.isArray(cover_image)
+    ? cover_image[0]?.url || cover_image[0]
+    : cover_image?.url || cover_image;
+
+  const hasCoverImage = Array.isArray(cover_image)
+    ? cover_image.length > 0
+    : Boolean(coverImage);
 
   return (
     <motion.div
@@ -23,7 +31,7 @@ export default function IssueInfoPanel({ issue }) {
       className="flex flex-col items-center gap-4 p-4 mt-4 border rounded bg-[var(--background)]"
       style={{ borderColor: "var(--border)" }}
     >
-      {coverImage && (
+      {hasCoverImage && (
         <ImageWithFallback
           src={coverImage}
           alt={title}


### PR DESCRIPTION
## Summary
- Normalize `cover_image` field and guard against empty arrays

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: ESLint couldn't find configuration file)

------
https://chatgpt.com/codex/tasks/task_e_68a932a2f6608321bae4200333c76065