### PR TITLE
Handle invalid image sources

### DIFF
--- a/src/components/ImageWithFallback.jsx
+++ b/src/components/ImageWithFallback.jsx
@@ -1,10 +1,14 @@
 import { useEffect, useState } from "react";
 
 export default function ImageWithFallback({ src, alt, className = "", ...props }) {
-  const [hasError, setHasError] = useState(!src);
+  const [hasError, setHasError] = useState(typeof src !== "string" || !src);
 
   useEffect(() => {
-    setHasError(!src);
+    const invalidSrc = typeof src !== "string" || !src;
+    if (typeof src !== "string") {
+      console.warn("ImageWithFallback: expected src to be a string, received", src);
+    }
+    setHasError(invalidSrc);
   }, [src]);
 
   if (hasError) {
@@ -28,4 +32,3 @@ export default function ImageWithFallback({ src, alt, className = "", ...props }
     />
   );
 }
-


### PR DESCRIPTION
## Summary
- guard against non-string or missing image src in ImageWithFallback
- warn in console when src is invalid to ease debugging

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a932ad28e483219d06ddb915cdbdc6