### PR TITLE
Resolve numeric cover images for WordPress issues

### DIFF
--- a/src/api/wordpress.js
+++ b/src/api/wordpress.js
@@ -51,6 +51,36 @@ export async function fetchMedia() {
   }
 }
 
+export async function fetchMediaItem(id) {
+  const endpoint = `${baseUrl}/wp-json/wp/v2/media/${id}`;
+  logRequest('Fetching media item', endpoint);
+  try {
+    const res = await fetch(endpoint, {
+      headers: {
+        ...authHeader(),
+      },
+    });
+    const authHeaderValue = res.headers.get('WWW-Authenticate');
+    if (res.status === 401 || res.status === 403) {
+      logError(
+        'WordPress authentication failed: missing or invalid credentials',
+        { status: res.status, authHeader: authHeaderValue }
+      );
+    }
+    if (!res.ok) {
+      logError('Failed to fetch media item', `${res.status} ${res.statusText}`);
+      throw new Error('Failed to fetch media item');
+    }
+    await ensureJsonResponse(res, 'Fetching media item');
+    const data = await res.json();
+    logSuccess('Fetched media item', { id });
+    return data;
+  } catch (err) {
+    logError('Error fetching media item', err);
+    throw err;
+  }
+}
+
 export async function fetchIssues() {
   const endpoint = `${baseUrl}/wp-json/wp/v2/issues?_embed`;
   logRequest('Fetching issues with ACF fields', endpoint);

--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -13,12 +13,14 @@ export default function IssueCarousel({ selectedId, onSelect }) {
   }
 
   const issues = issuePosts.map((issue) => {
-    const rawCover = issue.acf?.cover_image?.url || issue.acf?.cover_image;
+    const coverField = issue.acf?.cover_image;
+    const rawCover = Array.isArray(coverField)
+      ? coverField.find((item) => typeof item === "string" && item)
+      : coverField?.url || coverField;
     const coverImage =
-      typeof rawCover === "number" ||
-      (typeof rawCover === "string" && /^\d+$/.test(rawCover))
-        ? issue._embedded?.["wp:featuredmedia"]?.[0]?.source_url
-        : rawCover || issue._embedded?.["wp:featuredmedia"]?.[0]?.source_url;
+      typeof rawCover === "string" && rawCover
+        ? rawCover
+        : issue._embedded?.["wp:featuredmedia"]?.[0]?.source_url;
 
     return {
       id: issue.id,

--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -8,11 +8,15 @@ export default function IssueInfoPanel({ issue }) {
 
   const title = issue.title?.rendered || issue.title;
   const {
-    cover_image: coverImage,
+    cover_image: coverImageRaw,
     subtitle,
     long_description: description,
     credits,
   } = issue.acf || {};
+
+  const coverImage = Array.isArray(coverImageRaw)
+    ? coverImageRaw.find((item) => typeof item === "string" && item)
+    : coverImageRaw;
 
   return (
     <motion.div

--- a/src/hooks/useWordPressIssues.js
+++ b/src/hooks/useWordPressIssues.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { fetchIssues } from '../api/wordpress';
+import { fetchIssues, fetchMediaItem } from '../api/wordpress';
 
 export default function useWordPressIssues() {
   const [issues, setIssues] = useState([]);
@@ -11,6 +11,65 @@ export default function useWordPressIssues() {
     setError(null);
     try {
       const data = await fetchIssues();
+
+      const mediaIds = new Set();
+      for (const issue of data) {
+        const covers = issue.acf?.cover_image;
+        const items = Array.isArray(covers) ? covers : [covers];
+        for (const item of items) {
+          if (
+            typeof item === 'number' ||
+            (typeof item === 'string' && /^\d+$/.test(item))
+          ) {
+            mediaIds.add(item);
+          }
+        }
+      }
+
+      const mediaMap = {};
+      await Promise.all(
+        [...mediaIds].map(async (id) => {
+          try {
+            const media = await fetchMediaItem(id);
+            if (media?.source_url) {
+              mediaMap[id] = media.source_url;
+            }
+          } catch (e) {
+            // Ignore individual fetch errors
+          }
+        })
+      );
+
+      for (const issue of data) {
+        const covers = issue.acf?.cover_image;
+        if (Array.isArray(covers)) {
+          issue.acf.cover_image = covers.map((item) => {
+            if (typeof item === 'object' && item?.url) {
+              return item.url;
+            }
+            if (typeof item === 'string' && /^https?:\/\//.test(item)) {
+              return item;
+            }
+            if (
+              typeof item === 'number' ||
+              (typeof item === 'string' && /^\d+$/.test(item))
+            ) {
+              return mediaMap[item] || item;
+            }
+            return item;
+          });
+        } else if (covers) {
+          if (typeof covers === 'object' && covers?.url) {
+            issue.acf.cover_image = covers.url;
+          } else if (
+            typeof covers === 'number' ||
+            (typeof covers === 'string' && /^\d+$/.test(covers))
+          ) {
+            issue.acf.cover_image = mediaMap[covers] || covers;
+          }
+        }
+      }
+
       const sorted = [...data].sort((a, b) => {
         const aNum = Number(a.acf?.number);
         const bNum = Number(b.acf?.number);


### PR DESCRIPTION
## Summary
- resolve cover image media IDs to URLs when loading WordPress issues
- handle arrays of cover images in IssueCarousel and IssueInfoPanel
- add API helper for fetching single media items

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a932b9a2fc8321b43b808ae51b4b0a