### PR TITLE
feat: load home panels from WordPress

### DIFF
--- a/src/api/wordpress.js
+++ b/src/api/wordpress.js
@@ -80,6 +80,43 @@ export async function fetchIssues() {
     throw err;
   }
 }
+
+export async function fetchHomePanels() {
+  const endpoint = `${baseUrl}/wp-json/acf/v3/options/home_panels`;
+  logRequest('Fetching home panels', endpoint);
+  try {
+    const res = await fetch(endpoint, {
+      headers: {
+        ...authHeader(),
+      },
+    });
+    const authHeaderValue = res.headers.get('WWW-Authenticate');
+    if (res.status === 401 || res.status === 403) {
+      logError(
+        'WordPress authentication failed: missing or invalid credentials',
+        { status: res.status, authHeader: authHeaderValue }
+      );
+    }
+    if (!res.ok) {
+      logError('Failed to fetch home panels', `${res.status} ${res.statusText}`);
+      throw new Error('Failed to fetch home panels');
+    }
+    await ensureJsonResponse(res, 'Fetching home panels');
+    const data = await res.json();
+    const panels = Array.isArray(data?.acf?.home_panels)
+      ? data.acf.home_panels
+      : [];
+    const items = panels.map((item) => ({
+      label: item['panel-label'],
+      image: item['panel-image']?.url,
+    }));
+    logSuccess('Fetched home panels', { count: items.length });
+    return items;
+  } catch (err) {
+    logError('Error fetching home panels', err);
+    throw err;
+  }
+}
 export async function uploadMedia(file) {
   const formData = new FormData();
   formData.append('file', file);

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,13 +1,17 @@
 import { motion } from "framer-motion";
 import PanelCard from "./PanelCard";
 import ImageWithFallback from "./ImageWithFallback";
-const readImg = "/panels/read.jpg";
-const buyImg = "/panels/buy.jpg";
-const worldImg = "/panels/world.jpg";
-const meetImg = "/panels/meet.jpg";
-const connectImg = "/panels/connect.jpg";
+import useHomePanels from "../hooks/useHomePanels";
 
 export default function PanelGrid() {
+  const { panels } = useHomePanels();
+  const images = {
+    EXPLORE: panels["EXPLORE"]?.image ?? "/panels/world.jpg",
+    BUY: panels["BUY"]?.image ?? "/panels/buy.jpg",
+    READ: panels["READ"]?.image ?? "/panels/read.jpg",
+    MEET: panels["MEET"]?.image ?? "/panels/meet.jpg",
+    CONNECT: panels["CONNECT"]?.image ?? "/panels/connect.jpg",
+  };
   return (
     <div className="relative grid grid-rows-3 gap-4 w-full h-full">
       <motion.div
@@ -24,7 +28,7 @@ export default function PanelGrid() {
       <div className="grid h-full grid-cols-1 gap-4">
         <PanelCard
           className="bg-white h-full"
-          imageSrc={worldImg || undefined}
+          imageSrc={images.EXPLORE || undefined}
           label="EXPLORE"
           to="/world"
         />
@@ -32,13 +36,13 @@ export default function PanelGrid() {
       <div className="grid h-full grid-cols-2 gap-4">
         <PanelCard
           className="bg-white h-full"
-          imageSrc={buyImg || undefined}
+          imageSrc={images.BUY || undefined}
           label="BUY"
           to="/buy"
         />
         <PanelCard
           className="bg-white h-full"
-          imageSrc={readImg || undefined}
+          imageSrc={images.READ || undefined}
           label="READ"
           to="/read"
         />
@@ -46,13 +50,13 @@ export default function PanelGrid() {
       <div className="grid h-full grid-cols-2 gap-4">
         <PanelCard
           className="bg-white h-full"
-          imageSrc={meetImg || undefined}
+          imageSrc={images.MEET || undefined}
           label="MEET"
           to="/meet"
         />
         <PanelCard
           className="bg-white h-full"
-          imageSrc={connectImg || undefined}
+          imageSrc={images.CONNECT || undefined}
           label="CONNECT"
           to="/connect"
         />

--- a/src/hooks/useHomePanels.js
+++ b/src/hooks/useHomePanels.js
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { fetchHomePanels } from '../api/wordpress';
+
+export default function useHomePanels() {
+  const [panels, setPanels] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchHomePanels();
+        const map = {};
+        data.forEach((item) => {
+          if (item?.label) {
+            map[item.label] = { image: item.image };
+          }
+        });
+        setPanels(map);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, []);
+
+  return { panels, loading, error };
+}


### PR DESCRIPTION
## Summary
- fetch home panel data from WordPress ACF options API
- add React hook to load and map home panels
- use dynamic panel images on the home page with graceful fallbacks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_68a9341313308321a617a0582c2d3e6d