### PR TITLE
Adjust home panel field lookups for underscore slugs

### DIFF
--- a/src/api/wordpress.js
+++ b/src/api/wordpress.js
@@ -107,8 +107,8 @@ export async function fetchHomePanels() {
       ? data.acf.home_panels
       : [];
     const items = panels.map((item) => ({
-      label: item['panel-label'],
-      image: item['panel-image']?.url,
+      label: item['panel_label'],
+      image: item['panel_image']?.url,
     }));
     logSuccess('Fetched home panels', { count: items.length });
     return items;


### PR DESCRIPTION
## Summary
- Retrieve home panel fields using underscore slugs (`panel_label`, `panel_image`)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9367b13f48321889e4f63bb45ff1e