### PR TITLE
feat: support legacy home panels

### DIFF
--- a/src/api/wordpress.js
+++ b/src/api/wordpress.js
@@ -103,9 +103,8 @@ export async function fetchHomePanels() {
     }
     await ensureJsonResponse(res, 'Fetching home panels');
     const data = await res.json();
-    const panels = Array.isArray(data?.acf?.home_panels)
-      ? data.acf.home_panels
-      : [];
+    const rawPanels = data?.acf?.home_panels ?? data?.home_panels;
+    const panels = Array.isArray(rawPanels) ? rawPanels : [];
     const items = panels.map((item) => ({
       label: item['panel-label'],
       image: item['panel-image']?.url,


### PR DESCRIPTION
## Summary
- handle older home panel responses by checking `data.home_panels`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68a936ebcc348321863c74c53f71561d