### PR TITLE
feat: animate back button

### DIFF
--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -1,5 +1,6 @@
 import { useNavigate, useLocation } from "react-router-dom";
 import { motion } from "framer-motion";
+import { useState } from "react";
 import ImageWithFallback from "./ImageWithFallback";
 
 export default function BackButton() {
@@ -14,16 +15,33 @@ export default function BackButton() {
     "w-12 h-12 rounded-full border overflow-hidden transition-colors duration-200";
   const className = `${baseClasses} ${positionClasses}`;
 
+  const [leaving, setLeaving] = useState(false);
+
+  const variants = {
+    hidden: { opacity: 0, y: 10 },
+    visible: { opacity: 1, y: 0 },
+    exit: { opacity: 0, y: 10 },
+  };
+
+  const handleClick = () => {
+    setLeaving(true);
+  };
+
   return (
     <motion.button
-      layoutId="back-button"
       type="button"
       className={className}
       style={{ borderColor: "var(--border)" }}
-      onClick={() => navigate(-1)}
-      initial={{ opacity: 0, scale: 0.9 }}
-      animate={{ opacity: 1, scale: 1 }}
-      exit={{ opacity: 0, scale: 0.9 }}
+      onClick={handleClick}
+      initial="hidden"
+      animate={leaving ? "exit" : "visible"}
+      variants={variants}
+      transition={{ duration: 0.3 }}
+      onAnimationComplete={() => {
+        if (leaving) {
+          navigate(-1);
+        }
+      }}
     >
       <ImageWithFallback
         src="/logo.png"

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,6 +1,4 @@
-import { motion } from "framer-motion";
 import PanelCard from "./PanelCard";
-import ImageWithFallback from "./ImageWithFallback";
 import useHomePanels from "../hooks/useHomePanels";
 
 export default function PanelGrid() {
@@ -14,17 +12,6 @@ export default function PanelGrid() {
   };
   return (
     <div className="relative grid grid-rows-3 gap-4 w-full h-full">
-      <motion.div
-        layoutId="back-button"
-        className="absolute top-4 right-4 w-12 h-12 rounded-full border bg-white flex items-center justify-center overflow-hidden"
-        style={{ borderColor: "var(--border)" }}
-      >
-        <ImageWithFallback
-          src="/logo.png"
-          alt="Logo"
-          className="w-full h-full object-contain"
-        />
-      </motion.div>
       <div className="grid h-full grid-cols-1 gap-4">
         <PanelCard
           className="bg-white h-full"


### PR DESCRIPTION
## Summary
- remove static home button from the landing grid
- slide/fade back button on subpages and reverse before navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a93b22e6708321bc5f79b9fa39dcb4