### PR TITLE
Speed up page transitions and add horizontal slide

### DIFF
--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -18,9 +18,9 @@ export default function BackButton() {
   const [leaving, setLeaving] = useState(false);
 
   const variants = {
-    hidden: { opacity: 0, y: 10 },
-    visible: { opacity: 1, y: 0 },
-    exit: { opacity: 0, y: 10 },
+    hidden: { opacity: 0, x: -10 },
+    visible: { opacity: 1, x: 0 },
+    exit: { opacity: 0, x: -10 },
   };
 
   const handleClick = () => {
@@ -36,7 +36,7 @@ export default function BackButton() {
       initial="hidden"
       animate={leaving ? "exit" : "visible"}
       variants={variants}
-      transition={{ duration: 0.3 }}
+      transition={{ duration: 0.2 }}
       onAnimationComplete={() => {
         if (leaving) {
           navigate(-1);

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -5,12 +5,12 @@ import { motion } from "framer-motion";
 export default function Buy() {
   return (
     <PanelContent className="justify-start">
-      <motion.section
-        className="flex flex-col items-center justify-center gap-4 p-4 text-center hero-full"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-      >
+        <motion.section
+          className="flex flex-col items-center justify-center gap-4 p-4 text-center hero-full"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3 }}
+        >
         <div className="flex items-center gap-4">
           <BackButton />
           <motion.h1
@@ -20,21 +20,21 @@ export default function Buy() {
             BUY
           </motion.h1>
         </div>
-        <motion.p
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.2 }}
-          className="max-w-xl text-lg md:text-2xl"
-        >
+          <motion.p
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.3, delay: 0.1 }}
+            className="max-w-xl text-lg md:text-2xl"
+          >
           Support Renowned Home by backing our upcoming Kickstarter campaign.
         </motion.p>
-        <motion.a
-          href="#"
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.4 }}
-          className="mt-4 rounded bg-black px-8 py-3 font-bold uppercase text-white"
-        >
+          <motion.a
+            href="#"
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.3, delay: 0.2 }}
+            className="mt-4 rounded bg-black px-8 py-3 font-bold uppercase text-white"
+          >
           KICKSTARTER
         </motion.a>
       </motion.section>

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -27,12 +27,12 @@ export default function Connect() {
     return (
       <PanelContent className="justify-start">
       {/* Hero Section */}
-      <motion.section
-        className="relative flex-shrink-0 hero-half"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-      >
+        <motion.section
+          className="relative flex-shrink-0 hero-half"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3 }}
+        >
         <div className="relative flex flex-col items-center justify-center w-full h-full gap-4 p-4 text-center">
           <div className="flex items-center gap-4">
             <BackButton />
@@ -43,21 +43,21 @@ export default function Connect() {
               CONNECT
             </motion.h1>
           </div>
-          <motion.p
-            initial={{ opacity: 0, y: -20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.2 }}
-            className="max-w-xl text-lg md:text-2xl"
-          >
+            <motion.p
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.3, delay: 0.1 }}
+              className="max-w-xl text-lg md:text-2xl"
+            >
             Stay connected with Renowned Home.
           </motion.p>
-          <motion.form
-            initial={{ opacity: 0, y: -20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.4 }}
-            className="flex w-full max-w-md"
-            onSubmit={(e) => e.preventDefault()}
-          >
+            <motion.form
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.3, delay: 0.2 }}
+              className="flex w-full max-w-md"
+              onSubmit={(e) => e.preventDefault()}
+            >
             <input
               type="email"
               placeholder="Enter your email"
@@ -76,12 +76,12 @@ export default function Connect() {
       </motion.section>
 
       {/* Social Section */}
-      <motion.div
-        className="flex items-center justify-center w-full px-4 py-12"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, delay: 0.4 }}
-      >
+        <motion.div
+          className="flex items-center justify-center w-full px-4 py-12"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3, delay: 0.2 }}
+        >
         <div className="flex space-x-6">
           {socials.map((social) => (
             <a

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -15,12 +15,12 @@ export default function Meet() {
   return (
     <PanelContent className="justify-start">
       {/* Hero Section */}
-      <motion.section
-        className="relative flex-shrink-0 hero-half"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-      >
+        <motion.section
+          className="relative flex-shrink-0 hero-half"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3 }}
+        >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
           <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
             <div className="flex items-center gap-4">
@@ -32,12 +32,12 @@ export default function Meet() {
                 MEET
               </motion.h1>
             </div>
-            <motion.p
-              initial={{ opacity: 0, y: -20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.2 }}
-              className="max-w-xl text-lg md:text-2xl"
-            >
+              <motion.p
+                initial={{ opacity: 0, x: 20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.3, delay: 0.1 }}
+                className="max-w-xl text-lg md:text-2xl"
+              >
               Learn about the team behind Renowned Home.
             </motion.p>
           </div>
@@ -45,12 +45,12 @@ export default function Meet() {
       </motion.section>
 
       {/* Carousel + Info Section */}
-      <motion.div
-        className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, delay: 0.4 }}
-      >
+        <motion.div
+          className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3, delay: 0.2 }}
+        >
         <TeamCarousel selectedId={selectedMemberId} onSelect={handleSelect} />
         <AnimatePresence mode="wait">
           {selectedMemberId && (

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -18,12 +18,12 @@ export default function Read() {
   return (
     <PanelContent className="justify-start">
       {/* Hero Section */}
-      <motion.section
-        className="relative flex-shrink-0 hero-half"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-      >
+        <motion.section
+          className="relative flex-shrink-0 hero-half"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3 }}
+        >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
           <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
             <div className="flex items-center gap-4">
@@ -35,12 +35,12 @@ export default function Read() {
                 READ
               </motion.h1>
             </div>
-            <motion.p
-              initial={{ opacity: 0, y: -20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.2 }}
-              className="max-w-xl text-lg md:text-2xl"
-            >
+              <motion.p
+                initial={{ opacity: 0, x: 20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.3, delay: 0.1 }}
+                className="max-w-xl text-lg md:text-2xl"
+              >
               Explore the latest issue of Renowned Home.
             </motion.p>
           </div>
@@ -48,12 +48,12 @@ export default function Read() {
       </motion.section>
 
       {/* Carousel + Info Section */}
-      <motion.div
-        className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, delay: 0.4 }}
-      >
+        <motion.div
+          className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3, delay: 0.2 }}
+        >
         <IssueCarousel selectedId={selectedIssue?.id} onSelect={handleSelect} />
         <AnimatePresence mode="wait">
           {selectedIssue && (

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -5,12 +5,12 @@ import { motion } from "framer-motion";
 export default function World() {
   return (
     <PanelContent className="justify-start">
-      <motion.section
-        className="flex items-center justify-center hero-full"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-      >
+        <motion.section
+          className="flex items-center justify-center hero-full"
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3 }}
+        >
         <div className="flex items-center gap-4">
           <BackButton />
           <motion.h1


### PR DESCRIPTION
## Summary
- speed up back-button animation and slide it horizontally
- pages now fade while sliding in from the side with shorter durations

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9fc6d37448321ab64b520d779640a