### PR TITLE
fix: import WordPress media hook

### DIFF
--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
+import useWordPressMedia from "../hooks/useWordPressMedia";
 import ImageWithFallback from "./ImageWithFallback";
 import { fetchMediaById } from "../api/wordpress";
 


### PR DESCRIPTION
## Summary
- import WordPress media hook into IssueInfoPanel so hook call works

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html".)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fcfebf848321a7acce11e8792cd2