### PR TITLE
Handle loading and error states in Read page

### DIFF
--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -7,13 +7,29 @@ import BackButton from "../components/BackButton";
 import useWordPressIssues from "../hooks/useWordPressIssues";
 
 export default function Read() {
-  const { issues } = useWordPressIssues();
+  const { issues, loading, error } = useWordPressIssues();
   const [selectedIssue, setSelectedIssue] = useState(null);
 
   const handleSelect = (id) => {
     const issue = issues.find((i) => i.id === id);
     setSelectedIssue((prev) => (prev?.id === id ? null : issue));
   };
+
+  if (loading) {
+    return (
+      <PanelContent className="items-center justify-center">
+        <div>Loading issues...</div>
+      </PanelContent>
+    );
+  }
+
+  if (error) {
+    return (
+      <PanelContent className="items-center justify-center">
+        <div>Error loading issues: {error.message}</div>
+      </PanelContent>
+    );
+  }
 
   return (
     <PanelContent className="justify-start">


### PR DESCRIPTION
## Summary
- Display full-page loading indicator while WordPress issues are fetched
- Show descriptive error message if issues fail to load

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9fd3a1e1c83218a5e4aa6a5705f3d