### PR TITLE
refactor: pass WordPress issues to carousel

### DIFF
--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -1,10 +1,14 @@
 import { useEffect, useState } from "react";
-import useWordPressIssues from "../hooks/useWordPressIssues";
 import { fetchMediaById } from "../api/wordpress";
 import ImageWithFallback from "./ImageWithFallback";
 
-export default function IssueCarousel({ selectedId, onSelect }) {
-  const { issues: issuePosts, loading, error } = useWordPressIssues();
+export default function IssueCarousel({
+  issues: issuePosts,
+  loading,
+  error,
+  selectedId,
+  onSelect,
+}) {
   const [coverImages, setCoverImages] = useState({});
   const [coverLoading, setCoverLoading] = useState(true);
   const [coverError, setCoverError] = useState(null);

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -70,7 +70,13 @@ export default function Read() {
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3, delay: 0.2 }}
         >
-        <IssueCarousel selectedId={selectedIssue?.id} onSelect={handleSelect} />
+        <IssueCarousel
+          issues={issues}
+          loading={loading}
+          error={error}
+          selectedId={selectedIssue?.id}
+          onSelect={handleSelect}
+        />
         <AnimatePresence mode="wait">
           {selectedIssue && (
             <IssueInfoPanel issue={selectedIssue} key={selectedIssue.id} />


### PR DESCRIPTION
## Summary
- fetch WordPress issues once in `Read.jsx` and share loading/error data with `IssueCarousel`
- convert `IssueCarousel` to accept issues, loading and error props instead of using its own hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ff41cc2c83218d70bf2ba934fc91