### PR TITLE
Avoid rethrowing errors in WordPress issues hook

### DIFF
--- a/src/hooks/useWordPressIssues.js
+++ b/src/hooks/useWordPressIssues.js
@@ -20,6 +20,7 @@ export default function useWordPressIssues() {
       });
       setIssues(sorted);
     } catch (err) {
+      // Capture the error in state and let callers decide how to render it
       setError(err);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- document error handling in `useWordPressIssues` hook to avoid unhandled rejections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa019ddfd48321b9545028845a561b