### PR TITLE
feat: add Supabase home panels hook

### DIFF
--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -1,0 +1,27 @@
+import { logRequest, logSuccess, logError } from '../utils/logger';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export async function fetchHomePanels() {
+  const endpoint = `${supabaseUrl}/rest/v1/home_panels?select=label,image_url`;
+  logRequest('Fetching home panels from Supabase', endpoint);
+  try {
+    const res = await fetch(endpoint, {
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+      },
+    });
+    if (!res.ok) {
+      logError('Failed to fetch home panels from Supabase', `${res.status} ${res.statusText}`);
+      throw new Error('Failed to fetch home panels');
+    }
+    const data = await res.json();
+    logSuccess('Fetched home panels from Supabase', { count: data.length });
+    return data;
+  } catch (err) {
+    logError('Error fetching home panels from Supabase', err);
+    throw err;
+  }
+}

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,8 +1,8 @@
 import PanelCard from "./PanelCard";
-import useHomePanels from "../hooks/useHomePanels";
+import useSupabaseHomePanels from "../hooks/useSupabaseHomePanels";
 
 export default function PanelGrid() {
-  const { panels } = useHomePanels();
+  const { panels } = useSupabaseHomePanels();
   const images = {
     EXPLORE:
       typeof panels["EXPLORE"]?.image === "string"

--- a/src/hooks/useSupabaseHomePanels.js
+++ b/src/hooks/useSupabaseHomePanels.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { fetchHomePanels } from '../api/wordpress';
+import { fetchHomePanels } from '../api/supabase';
 
-export default function useHomePanels() {
+export default function useSupabaseHomePanels() {
   const [panels, setPanels] = useState({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -11,12 +11,13 @@ export default function useHomePanels() {
       setLoading(true);
       setError(null);
       try {
-        const data = await fetchHomePanels();
+        const rows = await fetchHomePanels();
         const map = {};
-        data.forEach((item) => {
-          if (item?.label) {
-            map[item.label] = {
-              image: typeof item.image === 'string' ? item.image : undefined,
+        rows.forEach((row) => {
+          if (row?.label) {
+            map[row.label] = {
+              image:
+                typeof row.image_url === 'string' ? row.image_url : undefined,
             };
           }
         });


### PR DESCRIPTION
## Summary
- rename home panel hook to use Supabase
- load home panel images from Supabase API
- update panel grid to use new hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af63165bf88321b4bd578ac19c5af2