### PR TITLE
Use Supabase issues data directly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@
 VITE_WP_BASE_URL=https://renownedcomic.com/wp-admin/
 VITE_WP_USERNAME=your_username
 VITE_WP_APP_PASSWORD=your_app_password
+VITE_SUPABASE_URL=https://your-supabase-url.supabase.co
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from "react";
-import { fetchMediaById } from "../api/wordpress";
 import ImageWithFallback from "./ImageWithFallback";
 
 export default function IssueCarousel({
@@ -9,11 +7,7 @@ export default function IssueCarousel({
   selectedId,
   onSelect,
 }) {
-  const [coverImages, setCoverImages] = useState({});
-  const [, setCoverLoading] = useState(true);
-  const [coverErrors, setCoverErrors] = useState({});
-
-  if (loading || coverLoading) {
+  if (loading) {
     return (
       <div className="w-full overflow-x-auto touch-pan-x">
         <div className="flex space-x-4 p-4">
@@ -34,121 +28,35 @@ export default function IssueCarousel({
     );
   }
 
-  if (error || coverError) {
+  if (error) {
     return <div>Error loading media.</div>;
   }
 
-  const isNumeric = (value) =>
-    typeof value === "number" || (typeof value === "string" && /^\d+$/.test(value));
-  useEffect(() => {
-    let active = true;
-    const fetchWithTimeout = (promise, ms = 10000) =>
-      Promise.race([
-        promise,
-        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), ms)),
-      ]);
-
-    const load = async () => {
-      if (!issuePosts.length) {
-        setCoverImages({});
-        setCoverErrors({});
-        setCoverLoading(false);
-        return;
-      }
-
-      setCoverLoading(true);
-      setCoverErrors({});
-
-      await Promise.allSettled(
-        issuePosts.map(async (issue) => {
-          const rawCoverField = issue.acf?.cover_image;
-          let value;
-          if (Array.isArray(rawCoverField)) {
-            const first = rawCoverField[0];
-            value = first?.url || first;
-          } else {
-            value = rawCoverField?.url || rawCoverField;
-          }
-          if (isNumeric(value)) {
-            try {
-              const mediaItem = await fetchWithTimeout(fetchMediaById(value));
-              if (active) {
-                setCoverImages((prev) => ({
-                  ...prev,
-                  [issue.id]: mediaItem?.source_url || "",
-                }));
-              }
-            } catch {
-              if (active) {
-                setCoverImages((prev) => ({ ...prev, [issue.id]: "" }));
-                setCoverErrors((prev) => ({ ...prev, [issue.id]: true }));
-              }
-            }
-            return;
-          }
-          if (active) {
-            setCoverImages((prev) => ({
-              ...prev,
-              [issue.id]:
-                value ||
-                issue._embedded?.["wp:featuredmedia"]?.[0]?.source_url ||
-                "",
-            }));
-          }
-        })
-      );
-
-      if (active) {
-        setCoverLoading(false);
-      }
-    };
-    load();
-    return () => {
-      active = false;
-    };
-  }, [issuePosts]);
-
   const issues = issuePosts.map((issue) => ({
     id: issue.id,
-    title: issue.title.rendered,
-    coverImage: coverImages[issue.id],
-    releaseDate: issue.acf.release_date,
-    shortDescription: issue.acf.short_description,
-    longDescription: issue.acf.long_description,
+    title: issue.title?.rendered || issue.title,
+    coverImage: issue.cover_image,
+    releaseDate: issue.release_date,
+    shortDescription: issue.short_description,
+    longDescription: issue.long_description,
   }));
-
-  const placeholders = Array.from({ length: 3 }, (_, i) => ({
-    id: `placeholder-${i}`,
-    placeholder: true,
-  }));
-
-  const displayIssues =
-    loading && issuePosts.length === 0 ? placeholders : issues;
 
   return (
     <div className="w-full overflow-x-auto touch-pan-x">
       <div className="flex space-x-4 p-4">
-        {displayIssues.map((issue) => {
-          const imageSrc = issue.placeholder ? undefined : coverImages[issue.id];
-          const imageError = coverErrors[issue.id];
-          const isLoaded = imageSrc !== undefined;
-          const handleClick = issue.placeholder
-            ? undefined
-            : () => onSelect?.(issue.id);
+        {issues.map((issue) => {
+          const imageSrc = issue.coverImage;
+          const handleClick = () => onSelect?.(issue.id);
           return (
             <div
               key={issue.id}
               onClick={handleClick}
-              className={`flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden min-w-[150px] sm:min-w-[200px] transition-transform ${
-                issue.placeholder
-                  ? ""
-                  : `cursor-pointer hover:scale-105 ${
-                      selectedId === issue.id ? "ring-2 ring-[var(--accent)]" : ""
-                    }`
+              className={`flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden min-w-[150px] sm:min-w-[200px] transition-transform cursor-pointer hover:scale-105 ${
+                selectedId === issue.id ? "ring-2 ring-[var(--accent)]" : ""
               }`}
               style={{ borderColor: "var(--border)" }}
             >
-              {isLoaded ? (
+              {imageSrc ? (
                 <ImageWithFallback
                   src={imageSrc}
                   alt={issue.title}
@@ -159,15 +67,12 @@ export default function IssueCarousel({
               )}
               <div className="p-2 text-center">
                 <p className="text-sm font-medium text-[var(--foreground)]">
-                  {issue.title ||
-                    (issue.placeholder ? (
-                      <span className="inline-block h-4 w-20 rounded bg-gray-200 animate-pulse" />
-                    ) : (
-                      ""
-                    ))}
+                  {issue.title || (
+                    <span className="inline-block h-4 w-20 rounded bg-gray-200 animate-pulse" />
+                  )}
                 </p>
               </div>
-              {imageError && (
+              {!imageSrc && (
                 <div className="p-1 text-center text-xs text-red-500">
                   Image unavailable
                 </div>

--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -1,52 +1,18 @@
-import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import useWordPressMedia from "../hooks/useWordPressMedia";
 import ImageWithFallback from "./ImageWithFallback";
-import { fetchMediaById } from "../api/wordpress";
 
 export default function IssueInfoPanel({ issue }) {
   if (!issue) {
     return null;
   }
 
-  const { media } = useWordPressMedia();
-
   const title = issue.title?.rendered || issue.title;
   const {
-    cover_image,
+    cover_image: coverImage,
     subtitle,
     long_description: description,
     credits,
-  } = issue.acf || {};
-
-  const isNumeric = (value) =>
-    typeof value === "number" || (typeof value === "string" && /^\d+$/.test(value));
-
-  const [coverImage, setCoverImage] = useState("");
-
-  useEffect(() => {
-    let active = true;
-    const resolveCover = async () => {
-      let raw = Array.isArray(cover_image) ? cover_image[0] : cover_image;
-      raw = raw?.url || raw;
-      if (isNumeric(raw)) {
-        try {
-          const mediaItem = await fetchMediaById(raw);
-          if (active) {
-            setCoverImage(mediaItem?.source_url || "");
-          }
-        } catch {
-          if (active) setCoverImage("");
-        }
-      } else {
-        setCoverImage(raw || "");
-      }
-    };
-    resolveCover();
-    return () => {
-      active = false;
-    };
-  }, [cover_image]);
+  } = issue;
 
   const hasCoverImage = Boolean(coverImage);
 

--- a/src/hooks/useSupabaseIssues.js
+++ b/src/hooks/useSupabaseIssues.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+export default function useSupabaseIssues() {
+  const [issues, setIssues] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      if (!url || !key) {
+        throw new Error("Supabase credentials are not configured");
+      }
+      const res = await fetch(`${url}/rest/v1/issues?select=*`, {
+        headers: {
+          apikey: key,
+          Authorization: `Bearer ${key}`,
+        },
+      });
+      if (!res.ok) {
+        throw new Error("Failed to fetch issues");
+      }
+      const data = await res.json();
+      setIssues(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return { issues, loading, error, refresh: load };
+}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -4,10 +4,10 @@ import PanelContent from "../components/PanelContent";
 import IssueCarousel from "../components/IssueCarousel";
 import IssueInfoPanel from "../components/IssueInfoPanel";
 import BackButton from "../components/BackButton";
-import useWordPressIssues from "../hooks/useWordPressIssues";
+import useSupabaseIssues from "../hooks/useSupabaseIssues";
 
 export default function Read() {
-  const { issues, loading, error } = useWordPressIssues();
+  const { issues, loading, error } = useSupabaseIssues();
   const [selectedIssue, setSelectedIssue] = useState(null);
 
   const handleSelect = (id) => {


### PR DESCRIPTION
## Summary
- replace WordPress issue fetching with Supabase hook
- simplify issue carousel and info panel to use direct cover image URLs and top-level fields
- document Supabase environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af631b88448321afb1f4f43313a946