### PR TITLE
Log Supabase configuration only in development

### DIFF
--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -4,6 +4,11 @@ import { logRequest, logSuccess, logError } from '../utils/logger';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
+if (import.meta.env.DEV) {
+  console.log('Supabase URL:', supabaseUrl);
+  console.log('Supabase anon key (first 6 chars):', supabaseAnonKey?.slice(0, 6));
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export async function fetchIssues() {

--- a/src/hooks/useSupabaseMedia.js
+++ b/src/hooks/useSupabaseMedia.js
@@ -5,6 +5,12 @@ const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 const mediaBucket = import.meta.env.VITE_SUPABASE_MEDIA_BUCKET || "media";
 
+if (import.meta.env.DEV) {
+  console.log("Supabase URL:", supabaseUrl);
+  console.log("Supabase anon key (first 6 chars):", supabaseKey?.slice(0, 6));
+  console.log("Supabase media bucket:", mediaBucket);
+}
+
 const supabase = createClient(supabaseUrl, supabaseKey);
 
 export default function useSupabaseMedia() {


### PR DESCRIPTION
## Summary
- add dev-only logs for Supabase URL and anon key when configuring the client
- log Supabase URL, anon key prefix, and media bucket in media hook for easier debugging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1fa73ebec8321ab4f6993e23bd4d4