### PR TITLE
chore: remove WP prefix from logger

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,13 +1,11 @@
-const prefix = '[WP API]';
-
 export function logRequest(message, info) {
-  console.info(`${prefix} ${message}`, info);
+  console.info(message, info);
 }
 
 export function logSuccess(message, info) {
-  console.info(`${prefix} Success: ${message}`, info);
+  console.info(`Success: ${message}`, info);
 }
 
 export function logError(message, error) {
-  console.error(`${prefix} Error: ${message}`, error);
+  console.error(`Error: ${message}`, error);
 }


### PR DESCRIPTION
## Summary
- stop prepending `[WP API]` in logging helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1fab5817883218b4fc0d38a4b89fe