### PR TITLE
feat: split issue credits into separate fields

### DIFF
--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -55,8 +55,12 @@ export default function IssueInfoPanel({ issue }) {
       {issue.long_description && (
         <p className="max-w-xl text-center">{issue.long_description}</p>
       )}
-      {issue.credits && (
-        <p className="text-sm text-gray-500 text-center">{issue.credits}</p>
+      {(issue.writer || issue.artist || issue.colorist) && (
+        <div className="text-sm text-gray-500 text-center">
+          {issue.writer && <p>Writer: {issue.writer}</p>}
+          {issue.artist && <p>Artist: {issue.artist}</p>}
+          {issue.colorist && <p>Colorist: {issue.colorist}</p>}
+        </div>
       )}
     </motion.div>
   );

--- a/src/data/issues.js
+++ b/src/data/issues.js
@@ -7,7 +7,9 @@ const issues = [
     coverImage: "https://via.placeholder.com/400x600?text=Issue+1+Cover",
     description:
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.",
-      credits: "Written by The MEET",
+    writer: "The MEET",
+    artist: "The MEET",
+    colorist: "The MEET",
   },
   {
     id: 2,
@@ -17,7 +19,9 @@ const issues = [
     coverImage: "https://via.placeholder.com/400x600?text=Issue+2+Cover",
     description:
       "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo.",
-      credits: "Written by The MEET",
+    writer: "The MEET",
+    artist: "The MEET",
+    colorist: "The MEET",
   },
   {
     id: 3,
@@ -27,7 +31,9 @@ const issues = [
     coverImage: "https://via.placeholder.com/400x600?text=Issue+3+Cover",
     description:
       "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
-      credits: "Written by The MEET",
+    writer: "The MEET",
+    artist: "The MEET",
+    colorist: "The MEET",
   },
 ];
 

--- a/src/hooks/useSupabaseIssues.js
+++ b/src/hooks/useSupabaseIssues.js
@@ -31,7 +31,9 @@ export default function useSupabaseIssues() {
         short_description: item.short_description,
         long_description: item.long_description,
         subtitle: item.subtitle,
-        credits: item.credits,
+        writer: item.writer,
+        artist: item.artist,
+        colorist: item.colorist,
       }));
 
       setIssues(mapped);


### PR DESCRIPTION
## Summary
- fetch writer, artist, and colorist separately for issues
- show issue credits as writer, artist, and colorist fields
- update sample issue data to use new credit fields

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b20437011c832199429c2dae9a9a7b