### PR TITLE
Add database-driven hero subtitles for key pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -54,3 +54,64 @@ if ( function_exists( 'acf_add_local_field_group' ) ) {
         'show_in_rest' => 1,
     ] );
 }
+
+/**
+ * Create table for page hero subtitles and expose a REST endpoint.
+ */
+function rh_create_page_subtitles_table() {
+    global $wpdb;
+    $table_name      = $wpdb->prefix . 'page_subtitles';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE $table_name (
+        id mediumint(9) NOT NULL AUTO_INCREMENT,
+        page_title varchar(191) NOT NULL,
+        headline_content text NOT NULL,
+        PRIMARY KEY  (id),
+        UNIQUE KEY page_title (page_title)
+    ) $charset_collate;";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta( $sql );
+
+    $defaults = [
+        [ 'buy', 'Support Renowned Home by backing our upcoming Kickstarter campaign.' ],
+        [ 'read', 'Explore the latest issue of Renowned Home.' ],
+        [ 'meet', 'Learn about the team behind Renowned Home.' ],
+        [ 'connect', 'Stay connected with Renowned Home.' ],
+    ];
+
+    foreach ( $defaults as $row ) {
+        $wpdb->replace(
+            $table_name,
+            [
+                'page_title'      => $row[0],
+                'headline_content'=> $row[1],
+            ],
+            [ '%s', '%s' ]
+        );
+    }
+}
+add_action( 'after_switch_theme', 'rh_create_page_subtitles_table' );
+
+add_action( 'rest_api_init', function() {
+    register_rest_route( 'renowned/v1', '/page-subtitle/(?P<page>[a-z0-9-]+)', [
+        'methods'             => WP_REST_Server::READABLE,
+        'permission_callback' => '__return_true',
+        'callback'            => function( WP_REST_Request $request ) {
+            global $wpdb;
+            $page  = sanitize_text_field( $request['page'] );
+            $table = $wpdb->prefix . 'page_subtitles';
+            $headline = $wpdb->get_var( $wpdb->prepare( "SELECT headline_content FROM $table WHERE page_title = %s", $page ) );
+
+            if ( null === $headline ) {
+                return new WP_Error( 'not_found', 'Page subtitle not found', [ 'status' => 404 ] );
+            }
+
+            return [
+                'page'             => $page,
+                'headline_content' => $headline,
+            ];
+        },
+    ] );
+} );

--- a/src/api/wordpress.js
+++ b/src/api/wordpress.js
@@ -164,6 +164,36 @@ export async function fetchHomePanels() {
     throw err;
   }
 }
+
+export async function fetchPageSubtitle(page) {
+  const endpoint = `${baseUrl}/wp-json/renowned/v1/page-subtitle/${page}`;
+  logRequest('Fetching page subtitle', endpoint);
+  try {
+    const res = await fetch(endpoint, {
+      headers: {
+        ...authHeader(),
+      },
+    });
+    const authHeaderValue = res.headers.get('WWW-Authenticate');
+    if (res.status === 401 || res.status === 403) {
+      logError(
+        'WordPress authentication failed: missing or invalid credentials',
+        { status: res.status, authHeader: authHeaderValue }
+      );
+    }
+    if (!res.ok) {
+      logError('Failed to fetch page subtitle', `${res.status} ${res.statusText}`);
+      throw new Error('Failed to fetch page subtitle');
+    }
+    await ensureJsonResponse(res, 'Fetching page subtitle');
+    const data = await res.json();
+    logSuccess('Fetched page subtitle', { page: data.page });
+    return data;
+  } catch (err) {
+    logError('Error fetching page subtitle', err);
+    throw err;
+  }
+}
 export async function uploadMedia(file) {
   const formData = new FormData();
   formData.append('file', file);

--- a/src/hooks/usePageSubtitle.js
+++ b/src/hooks/usePageSubtitle.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { fetchPageSubtitle } from "../api/wordpress";
+
+export default function usePageSubtitle(page) {
+  const [headline, setHeadline] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchPageSubtitle(page);
+        if (isMounted) {
+          setHeadline(data?.headline_content ?? "");
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+    load();
+    return () => {
+      isMounted = false;
+    };
+  }, [page]);
+
+  return { headline, loading, error };
+}

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,8 +1,10 @@
 import PanelContent from "../components/PanelContent";
 import BackButton from "../components/BackButton";
 import { motion } from "framer-motion";
+import usePageSubtitle from "../hooks/usePageSubtitle";
 
 export default function Buy() {
+  const { headline } = usePageSubtitle("buy");
   return (
     <PanelContent className="justify-start">
         <motion.section
@@ -26,7 +28,7 @@ export default function Buy() {
             transition={{ duration: 0.3, delay: 0.1 }}
             className="max-w-xl text-lg md:text-2xl"
           >
-          Support Renowned Home by backing our upcoming Kickstarter campaign.
+          {headline}
         </motion.p>
           <motion.a
             href="#"

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -1,6 +1,7 @@
 import PanelContent from "../components/PanelContent";
 import BackButton from "../components/BackButton";
 import { motion } from "framer-motion";
+import usePageSubtitle from "../hooks/usePageSubtitle";
 
 export default function Connect() {
   const socials = [
@@ -24,6 +25,7 @@ export default function Connect() {
     },
   ];
 
+    const { headline } = usePageSubtitle("connect");
     return (
       <PanelContent className="justify-start">
       {/* Hero Section */}
@@ -49,7 +51,7 @@ export default function Connect() {
               transition={{ duration: 0.3, delay: 0.1 }}
               className="max-w-xl text-lg md:text-2xl"
             >
-            Stay connected with Renowned Home.
+            {headline}
           </motion.p>
             <motion.form
               initial={{ opacity: 0, x: 20 }}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -4,9 +4,11 @@ import PanelContent from "../components/PanelContent";
 import TeamCarousel from "../components/TeamCarousel";
 import TeamInfoPanel from "../components/TeamInfoPanel";
 import BackButton from "../components/BackButton";
+import usePageSubtitle from "../hooks/usePageSubtitle";
 
 export default function Meet() {
   const [selectedMemberId, setSelectedMemberId] = useState(null);
+  const { headline } = usePageSubtitle("meet");
 
   const handleSelect = (id) => {
     setSelectedMemberId((prev) => (prev === id ? null : id));
@@ -38,7 +40,7 @@ export default function Meet() {
                 transition={{ duration: 0.3, delay: 0.1 }}
                 className="max-w-xl text-lg md:text-2xl"
               >
-              Learn about the team behind Renowned Home.
+              {headline}
             </motion.p>
           </div>
         </div>

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -5,10 +5,12 @@ import IssueCarousel from "../components/IssueCarousel";
 import IssueInfoPanel from "../components/IssueInfoPanel";
 import BackButton from "../components/BackButton";
 import useSupabaseIssues from "../hooks/useSupabaseIssues";
+import usePageSubtitle from "../hooks/usePageSubtitle";
 
 export default function Read() {
   const { issues, loading, error } = useSupabaseIssues();
   const [selectedIssue, setSelectedIssue] = useState(null);
+  const { headline } = usePageSubtitle("read");
 
   const handleSelect = (id) => {
     const issue = issues.find((i) => i.id === id);
@@ -49,7 +51,7 @@ export default function Read() {
                 transition={{ duration: 0.3, delay: 0.1 }}
                 className="max-w-xl text-lg md:text-2xl"
               >
-              Explore the latest issue of Renowned Home.
+              {headline}
             </motion.p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- create `page_subtitles` table and REST endpoint to serve hero subtitles
- add API helper and React hook for fetching page subtitles
- use dynamic subtitles on Buy, Read, Meet, and Connect pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b209e410dc832186abb88dff6559c4