### PR TITLE
Use Supabase IDs for panel images

### DIFF
--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -5,24 +5,24 @@ export default function PanelGrid() {
   const { panels } = useSupabaseHomePanels();
   const images = {
     EXPLORE:
-      typeof panels["EXPLORE"]?.image === "string"
-        ? panels["EXPLORE"].image
+      typeof panels[1]?.image === "string"
+        ? panels[1].image
         : "/panels/world.jpg",
     BUY:
-      typeof panels["BUY"]?.image === "string"
-        ? panels["BUY"].image
+      typeof panels[2]?.image === "string"
+        ? panels[2].image
         : "/panels/buy.jpg",
     READ:
-      typeof panels["READ"]?.image === "string"
-        ? panels["READ"].image
+      typeof panels[3]?.image === "string"
+        ? panels[3].image
         : "/panels/read.jpg",
     MEET:
-      typeof panels["MEET"]?.image === "string"
-        ? panels["MEET"].image
+      typeof panels[4]?.image === "string"
+        ? panels[4].image
         : "/panels/meet.jpg",
     CONNECT:
-      typeof panels["CONNECT"]?.image === "string"
-        ? panels["CONNECT"].image
+      typeof panels[5]?.image === "string"
+        ? panels[5].image
         : "/panels/connect.jpg",
   };
   return (

--- a/src/hooks/useSupabaseHomePanels.js
+++ b/src/hooks/useSupabaseHomePanels.js
@@ -14,8 +14,8 @@ export default function useSupabaseHomePanels() {
         const rows = await fetchHomePanels();
         const map = {};
         rows.forEach((row) => {
-          if (row?.label) {
-            map[row.label] = {
+          if (typeof row?.id === 'number') {
+            map[row.id] = {
               image:
                 typeof row.image_url === 'string' ? row.image_url : undefined,
             };


### PR DESCRIPTION
## Summary
- load home panel images by their Supabase IDs
- adjust hook to map image URLs by numeric ID

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b20b37fb988321a459b9335ec8b643