### PR TITLE
Fetch page subtitles by numeric ID

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -95,22 +95,23 @@ function rh_create_page_subtitles_table() {
 add_action( 'after_switch_theme', 'rh_create_page_subtitles_table' );
 
 add_action( 'rest_api_init', function() {
-    register_rest_route( 'renowned/v1', '/page-subtitle/(?P<page>[a-z0-9-]+)', [
+    register_rest_route( 'renowned/v1', '/page-subtitle/(?P<id>\d+)', [
         'methods'             => WP_REST_Server::READABLE,
         'permission_callback' => '__return_true',
         'callback'            => function( WP_REST_Request $request ) {
             global $wpdb;
-            $page  = sanitize_text_field( $request['page'] );
+            $id    = absint( $request['id'] );
             $table = $wpdb->prefix . 'page_subtitles';
-            $headline = $wpdb->get_var( $wpdb->prepare( "SELECT headline_content FROM $table WHERE page_title = %s", $page ) );
+            $row   = $wpdb->get_row( $wpdb->prepare( "SELECT page_title, headline_content FROM $table WHERE id = %d", $id ) );
 
-            if ( null === $headline ) {
+            if ( null === $row ) {
                 return new WP_Error( 'not_found', 'Page subtitle not found', [ 'status' => 404 ] );
             }
 
             return [
-                'page'             => $page,
-                'headline_content' => $headline,
+                'id'               => $id,
+                'page'             => $row->page_title,
+                'headline_content' => $row->headline_content,
             ];
         },
     ] );

--- a/src/api/wordpress.js
+++ b/src/api/wordpress.js
@@ -165,8 +165,8 @@ export async function fetchHomePanels() {
   }
 }
 
-export async function fetchPageSubtitle(page) {
-  const endpoint = `${baseUrl}/wp-json/renowned/v1/page-subtitle/${page}`;
+export async function fetchPageSubtitle(id) {
+  const endpoint = `${baseUrl}/wp-json/renowned/v1/page-subtitle/${id}`;
   logRequest('Fetching page subtitle', endpoint);
   try {
     const res = await fetch(endpoint, {
@@ -187,7 +187,7 @@ export async function fetchPageSubtitle(page) {
     }
     await ensureJsonResponse(res, 'Fetching page subtitle');
     const data = await res.json();
-    logSuccess('Fetched page subtitle', { page: data.page });
+    logSuccess('Fetched page subtitle', { id: data.id ?? id });
     return data;
   } catch (err) {
     logError('Error fetching page subtitle', err);

--- a/src/hooks/usePageSubtitle.js
+++ b/src/hooks/usePageSubtitle.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { fetchPageSubtitle } from "../api/wordpress";
 
-export default function usePageSubtitle(page) {
+export default function usePageSubtitle(id) {
   const [headline, setHeadline] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -12,7 +12,7 @@ export default function usePageSubtitle(page) {
       setLoading(true);
       setError(null);
       try {
-        const data = await fetchPageSubtitle(page);
+        const data = await fetchPageSubtitle(id);
         if (isMounted) {
           setHeadline(data?.headline_content ?? "");
         }
@@ -30,7 +30,7 @@ export default function usePageSubtitle(page) {
     return () => {
       isMounted = false;
     };
-  }, [page]);
+  }, [id]);
 
   return { headline, loading, error };
 }

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion";
 import usePageSubtitle from "../hooks/usePageSubtitle";
 
 export default function Buy() {
-  const { headline } = usePageSubtitle("buy");
+  const { headline } = usePageSubtitle(1);
   return (
     <PanelContent className="justify-start">
         <motion.section

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -25,7 +25,7 @@ export default function Connect() {
     },
   ];
 
-    const { headline } = usePageSubtitle("connect");
+    const { headline } = usePageSubtitle(4);
     return (
       <PanelContent className="justify-start">
       {/* Hero Section */}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -8,7 +8,7 @@ import usePageSubtitle from "../hooks/usePageSubtitle";
 
 export default function Meet() {
   const [selectedMemberId, setSelectedMemberId] = useState(null);
-  const { headline } = usePageSubtitle("meet");
+  const { headline } = usePageSubtitle(3);
 
   const handleSelect = (id) => {
     setSelectedMemberId((prev) => (prev === id ? null : id));

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -10,7 +10,7 @@ import usePageSubtitle from "../hooks/usePageSubtitle";
 export default function Read() {
   const { issues, loading, error } = useSupabaseIssues();
   const [selectedIssue, setSelectedIssue] = useState(null);
-  const { headline } = usePageSubtitle("read");
+  const { headline } = usePageSubtitle(2);
 
   const handleSelect = (id) => {
     const issue = issues.find((i) => i.id === id);


### PR DESCRIPTION
## Summary
- Fetch page subtitles via numeric ID rather than slug
- Update React pages to request subtitles using numeric IDs
- Provide new WordPress REST route resolving subtitle by ID

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b20d004c708321b7e4dc0886df13cc