### PR TITLE
Use Supabase for hero subtitles

### DIFF
--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -43,6 +43,26 @@ export async function fetchHomePanels() {
   }
 }
 
+export async function fetchPageSubtitle(id) {
+  logRequest('Fetching page subtitle from Supabase', { id });
+  try {
+    const { data, error } = await supabase
+      .from('page_subtitles')
+      .select('*')
+      .eq('id', id)
+      .single();
+    if (error) {
+      logError('Error fetching page subtitle', error);
+      throw error;
+    }
+    logSuccess('Fetched page subtitle', { id: data?.id ?? id });
+    return data ?? null;
+  } catch (err) {
+    logError('Unexpected error fetching page subtitle', err);
+    throw err;
+  }
+}
+
 export async function fetchMediaList() {
   logRequest('Fetching media list from Supabase');
   try {

--- a/src/api/wordpress.js
+++ b/src/api/wordpress.js
@@ -164,36 +164,6 @@ export async function fetchHomePanels() {
     throw err;
   }
 }
-
-export async function fetchPageSubtitle(id) {
-  const endpoint = `${baseUrl}/wp-json/renowned/v1/page-subtitle/${id}`;
-  logRequest('Fetching page subtitle', endpoint);
-  try {
-    const res = await fetch(endpoint, {
-      headers: {
-        ...authHeader(),
-      },
-    });
-    const authHeaderValue = res.headers.get('WWW-Authenticate');
-    if (res.status === 401 || res.status === 403) {
-      logError(
-        'WordPress authentication failed: missing or invalid credentials',
-        { status: res.status, authHeader: authHeaderValue }
-      );
-    }
-    if (!res.ok) {
-      logError('Failed to fetch page subtitle', `${res.status} ${res.statusText}`);
-      throw new Error('Failed to fetch page subtitle');
-    }
-    await ensureJsonResponse(res, 'Fetching page subtitle');
-    const data = await res.json();
-    logSuccess('Fetched page subtitle', { id: data.id ?? id });
-    return data;
-  } catch (err) {
-    logError('Error fetching page subtitle', err);
-    throw err;
-  }
-}
 export async function uploadMedia(file) {
   const formData = new FormData();
   formData.append('file', file);

--- a/src/hooks/usePageSubtitle.js
+++ b/src/hooks/usePageSubtitle.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { fetchPageSubtitle } from "../api/wordpress";
+import { fetchPageSubtitle } from "../api/supabase";
 
 export default function usePageSubtitle(id) {
   const [headline, setHeadline] = useState("");


### PR DESCRIPTION
## Summary
- Fetch page hero subtitles from Supabase `page_subtitles` table
- Update page subtitle hook to use Supabase instead of WordPress
- Remove WordPress page subtitle API implementation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3ba98eff483219835f8bae2411ea7