### PR TITLE
Center hero headers and reposition home button

### DIFF
--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -9,7 +9,7 @@ export default function BackButton() {
   if (isHome) {
     return null;
   }
-  const positionClasses = "mr-2";
+  const positionClasses = "fixed top-4 left-4 z-50";
   const baseClasses =
     "w-12 h-12 rounded-full border overflow-hidden transition-colors duration-200";
   const className = `${baseClasses} ${positionClasses}`;

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -8,25 +8,23 @@ export default function Buy() {
   return (
     <PanelContent className="justify-start">
         <motion.section
-          className="flex flex-col items-center justify-center gap-4 p-4 text-center hero-full"
+          className="relative flex flex-col items-center justify-center p-4 text-center hero-full"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-        <div className="flex items-center gap-4">
-          <BackButton />
-          <motion.h1
+        <BackButton />
+        <motion.h1
             layoutId="BUY"
-            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)] mb-2"
           >
             BUY
           </motion.h1>
-        </div>
           <motion.p
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.3, delay: 0.1 }}
-            className="max-w-xl text-lg md:text-2xl"
+            className="max-w-xl text-lg md:text-2xl mb-4"
           >
           {headline}
         </motion.p>
@@ -35,7 +33,7 @@ export default function Buy() {
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.3, delay: 0.2 }}
-            className="mt-4 rounded bg-black px-8 py-3 font-bold uppercase text-white"
+            className="rounded bg-black px-8 py-3 font-bold uppercase text-white"
           >
           KICKSTARTER
         </motion.a>

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -35,21 +35,19 @@ export default function Connect() {
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-        <div className="relative flex flex-col items-center justify-center w-full h-full gap-4 p-4 text-center">
-          <div className="flex items-center gap-4">
-            <BackButton />
+        <BackButton />
+        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
             <motion.h1
               layoutId="CONNECT"
-              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)] mb-2"
             >
               CONNECT
             </motion.h1>
-          </div>
             <motion.p
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.3, delay: 0.1 }}
-              className="max-w-xl text-lg md:text-2xl"
+              className="max-w-xl text-lg md:text-2xl mb-4"
             >
             {headline}
           </motion.p>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -24,16 +24,13 @@ export default function Meet() {
           transition={{ duration: 0.3 }}
         >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
-          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
-            <div className="flex items-center gap-4">
-              <BackButton />
-              <motion.h1
+            <BackButton />
+            <motion.h1
                 layoutId="MEET"
-                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)] mb-2"
               >
                 MEET
               </motion.h1>
-            </div>
               <motion.p
                 initial={{ opacity: 0, x: 20 }}
                 animate={{ opacity: 1, x: 0 }}
@@ -43,7 +40,6 @@ export default function Meet() {
               {headline}
             </motion.p>
           </div>
-        </div>
       </motion.section>
 
       {/* Carousel + Info Section */}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -35,16 +35,13 @@ export default function Read() {
           transition={{ duration: 0.3 }}
         >
         <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
-          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
-            <div className="flex items-center gap-4">
-              <BackButton />
-              <motion.h1
+            <BackButton />
+            <motion.h1
                 layoutId="READ"
-                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)] mb-2"
               >
                 READ
               </motion.h1>
-            </div>
               <motion.p
                 initial={{ opacity: 0, x: 20 }}
                 animate={{ opacity: 1, x: 0 }}
@@ -54,7 +51,6 @@ export default function Read() {
               {headline}
             </motion.p>
           </div>
-        </div>
       </motion.section>
 
       {/* Carousel + Info Section */}

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -6,20 +6,18 @@ export default function World() {
   return (
     <PanelContent className="justify-start">
         <motion.section
-          className="flex items-center justify-center hero-full"
+          className="relative flex items-center justify-center hero-full"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-        <div className="flex items-center gap-4">
-          <BackButton />
-          <motion.h1
+        <BackButton />
+        <motion.h1
             layoutId="EXPLORE"
             className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
           >
             EXPLORE
           </motion.h1>
-        </div>
       </motion.section>
     </PanelContent>
   );


### PR DESCRIPTION
## Summary
- Fix home button to the top-left corner across subpages
- Center hero headers and tighten spacing to subtitles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b482999aac83218f0318895831b8e2