### PR TITLE
feat: add animated route transitions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
-import { Routes, Route, Navigate } from "react-router-dom";
-import { LayoutGroup } from "framer-motion";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
+import { LayoutGroup, AnimatePresence } from "framer-motion";
 
 import PanelGrid from "./components/PanelGrid";
 import Read from "./pages/Read";
@@ -9,21 +9,25 @@ import Meet from "./pages/Meet";
 import Connect from "./pages/Connect";
 
 export default function App() {
+  const location = useLocation();
+
   return (
     <div
       className="relative w-screen h-screen overflow-x-hidden overflow-y-auto border-4 p-4"
       style={{ borderColor: "var(--border)" }}
     >
       <LayoutGroup>
-        <Routes>
-          <Route path="/" element={<PanelGrid />} />
-          <Route path="/read" element={<Read />} />
-          <Route path="/buy" element={<Buy />} />
-          <Route path="/world" element={<World />} />
-          <Route path="/meet" element={<Meet />} />
-          <Route path="/connect" element={<Connect />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
+        <AnimatePresence mode="wait">
+          <Routes location={location} key={location.pathname}>
+            <Route path="/" element={<PanelGrid />} />
+            <Route path="/read" element={<Read />} />
+            <Route path="/buy" element={<Buy />} />
+            <Route path="/world" element={<World />} />
+            <Route path="/meet" element={<Meet />} />
+            <Route path="/connect" element={<Connect />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </AnimatePresence>
       </LayoutGroup>
     </div>
   );

--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -20,7 +20,7 @@ export default function BackButton() {
   };
 
   const handleClick = () => {
-    navigate(-1);
+    navigate("/", { state: { fromPage: true } });
   };
 
   return (

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -9,7 +9,8 @@ export default function PanelCard({
   to,
 }) {
   const content = (
-    <div
+    <motion.div
+      layoutId={`panel-${label}`}
       className={`relative w-full h-full cursor-pointer group border bg-[var(--background)] ${className}`}
       style={{ borderColor: "var(--border)" }}
     >
@@ -31,7 +32,7 @@ export default function PanelCard({
           </motion.span>
         </div>
       )}
-    </div>
+    </motion.div>
   );
 
   return to ? (

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -6,30 +6,37 @@ import usePageSubtitle from "../hooks/usePageSubtitle";
 export default function Buy() {
   const { headline } = usePageSubtitle(1);
   return (
-    <PanelContent className="justify-start">
+    <motion.div
+      layoutId="panel-BUY"
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      className="w-full h-full"
+    >
+      <PanelContent className="justify-start">
         <motion.section
           className="flex flex-col items-center justify-center gap-4 p-4 text-center hero-full"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-        <div className="flex items-center gap-4">
-          <BackButton />
-          <motion.h1
-            layoutId="BUY"
-            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-          >
-            BUY
-          </motion.h1>
-        </div>
+          <div className="flex items-center gap-4">
+            <BackButton />
+            <motion.h1
+              layoutId="BUY"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            >
+              BUY
+            </motion.h1>
+          </div>
           <motion.p
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.3, delay: 0.1 }}
             className="max-w-xl text-lg md:text-2xl"
           >
-          {headline}
-        </motion.p>
+            {headline}
+          </motion.p>
           <motion.a
             href="#"
             initial={{ opacity: 0, x: 20 }}
@@ -37,9 +44,10 @@ export default function Buy() {
             transition={{ duration: 0.3, delay: 0.2 }}
             className="mt-4 rounded bg-black px-8 py-3 font-bold uppercase text-white"
           >
-          KICKSTARTER
-        </motion.a>
-      </motion.section>
-    </PanelContent>
+            KICKSTARTER
+          </motion.a>
+        </motion.section>
+      </PanelContent>
+    </motion.div>
   );
 }

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -25,34 +25,41 @@ export default function Connect() {
     },
   ];
 
-    const { headline } = usePageSubtitle(4);
-    return (
+  const { headline } = usePageSubtitle(4);
+  return (
+    <motion.div
+      layoutId="panel-CONNECT"
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      className="w-full h-full"
+    >
       <PanelContent className="justify-start">
-      {/* Hero Section */}
+        {/* Hero Section */}
         <motion.section
           className="relative flex-shrink-0 hero-half"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-        <div className="relative flex flex-col items-center justify-center w-full h-full gap-4 p-4 text-center">
-          <div className="flex items-center gap-4">
-            <BackButton />
-            <motion.h1
-              layoutId="CONNECT"
-              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-            >
-              CONNECT
-            </motion.h1>
-          </div>
+          <div className="relative flex flex-col items-center justify-center w-full h-full gap-4 p-4 text-center">
+            <div className="flex items-center gap-4">
+              <BackButton />
+              <motion.h1
+                layoutId="CONNECT"
+                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              >
+                CONNECT
+              </motion.h1>
+            </div>
             <motion.p
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.3, delay: 0.1 }}
               className="max-w-xl text-lg md:text-2xl"
             >
-            {headline}
-          </motion.p>
+              {headline}
+            </motion.p>
             <motion.form
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
@@ -60,49 +67,50 @@ export default function Connect() {
               className="flex w-full max-w-md"
               onSubmit={(e) => e.preventDefault()}
             >
-            <input
-              type="email"
-              placeholder="Enter your email"
-              className="flex-grow rounded-l border p-2 bg-[var(--background)] text-[var(--foreground)]"
-              style={{ borderColor: "var(--border)" }}
-            />
-            <button
-              type="submit"
-              className="rounded-r border p-2 bg-[var(--accent)] text-white"
-              style={{ borderColor: "var(--border)" }}
-            >
-              Submit
-            </button>
-          </motion.form>
-        </div>
-      </motion.section>
+              <input
+                type="email"
+                placeholder="Enter your email"
+                className="flex-grow rounded-l border p-2 bg-[var(--background)] text-[var(--foreground)]"
+                style={{ borderColor: "var(--border)" }}
+              />
+              <button
+                type="submit"
+                className="rounded-r border p-2 bg-[var(--accent)] text-white"
+                style={{ borderColor: "var(--border)" }}
+              >
+                Submit
+              </button>
+            </motion.form>
+          </div>
+        </motion.section>
 
-      {/* Social Section */}
+        {/* Social Section */}
         <motion.div
           className="flex items-center justify-center w-full px-4 py-12"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3, delay: 0.2 }}
         >
-        <div className="flex space-x-6">
-          {socials.map((social) => (
-            <a
-              key={social.id}
-              href={social.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="w-24 h-24 border rounded-full overflow-hidden flex items-center justify-center"
-              style={{ borderColor: "var(--border)" }}
-            >
-              <img
-                src={social.img}
-                alt={social.alt}
-                className="w-full h-full object-cover"
-              />
-            </a>
-          ))}
-        </div>
-      </motion.div>
-    </PanelContent>
+          <div className="flex space-x-6">
+            {socials.map((social) => (
+              <a
+                key={social.id}
+                href={social.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="w-24 h-24 border rounded-full overflow-hidden flex items-center justify-center"
+                style={{ borderColor: "var(--border)" }}
+              >
+                <img
+                  src={social.img}
+                  alt={social.alt}
+                  className="w-full h-full object-cover"
+                />
+              </a>
+            ))}
+          </div>
+        </motion.div>
+      </PanelContent>
+    </motion.div>
   );
 }

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -15,51 +15,59 @@ export default function Meet() {
   };
 
   return (
-    <PanelContent className="justify-start">
-      {/* Hero Section */}
+    <motion.div
+      layoutId="panel-MEET"
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      className="w-full h-full"
+    >
+      <PanelContent className="justify-start">
+        {/* Hero Section */}
         <motion.section
           className="relative flex-shrink-0 hero-half"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
-          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
-            <div className="flex items-center gap-4">
-              <BackButton />
-              <motion.h1
-                layoutId="MEET"
-                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-              >
-                MEET
-              </motion.h1>
-            </div>
+          <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
+            <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
+              <div className="flex items-center gap-4">
+                <BackButton />
+                <motion.h1
+                  layoutId="MEET"
+                  className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+                >
+                  MEET
+                </motion.h1>
+              </div>
               <motion.p
                 initial={{ opacity: 0, x: 20 }}
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.3, delay: 0.1 }}
                 className="max-w-xl text-lg md:text-2xl"
               >
-              {headline}
-            </motion.p>
+                {headline}
+              </motion.p>
+            </div>
           </div>
-        </div>
-      </motion.section>
+        </motion.section>
 
-      {/* Carousel + Info Section */}
+        {/* Carousel + Info Section */}
         <motion.div
           className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3, delay: 0.2 }}
         >
-        <TeamCarousel selectedId={selectedMemberId} onSelect={handleSelect} />
-        <AnimatePresence mode="wait">
-          {selectedMemberId && (
-            <TeamInfoPanel memberId={selectedMemberId} key={selectedMemberId} />
-          )}
-        </AnimatePresence>
-      </motion.div>
-    </PanelContent>
+          <TeamCarousel selectedId={selectedMemberId} onSelect={handleSelect} />
+          <AnimatePresence mode="wait">
+            {selectedMemberId && (
+              <TeamInfoPanel memberId={selectedMemberId} key={selectedMemberId} />
+            )}
+          </AnimatePresence>
+        </motion.div>
+      </PanelContent>
+    </motion.div>
   );
 }

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -26,57 +26,65 @@ export default function Read() {
   }
 
   return (
-    <PanelContent className="justify-start">
-      {/* Hero Section */}
+    <motion.div
+      layoutId="panel-READ"
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      className="w-full h-full"
+    >
+      <PanelContent className="justify-start">
+        {/* Hero Section */}
         <motion.section
           className="relative flex-shrink-0 hero-half"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-        <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
-          <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
-            <div className="flex items-center gap-4">
-              <BackButton />
-              <motion.h1
-                layoutId="READ"
-                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-              >
-                READ
-              </motion.h1>
-            </div>
+          <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
+            <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
+              <div className="flex items-center gap-4">
+                <BackButton />
+                <motion.h1
+                  layoutId="READ"
+                  className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+                >
+                  READ
+                </motion.h1>
+              </div>
               <motion.p
                 initial={{ opacity: 0, x: 20 }}
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.3, delay: 0.1 }}
                 className="max-w-xl text-lg md:text-2xl"
               >
-              {headline}
-            </motion.p>
+                {headline}
+              </motion.p>
+            </div>
           </div>
-        </div>
-      </motion.section>
+        </motion.section>
 
-      {/* Carousel + Info Section */}
+        {/* Carousel + Info Section */}
         <motion.div
           className="flex flex-col items-center justify-center w-full px-4 py-12 space-y-8"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3, delay: 0.2 }}
         >
-        <IssueCarousel
-          issues={issues}
-          loading={loading}
-          error={error}
-          selectedId={selectedIssue?.id}
-          onSelect={handleSelect}
-        />
-        <AnimatePresence mode="wait">
-          {!loading && selectedIssue && (
-            <IssueInfoPanel issue={selectedIssue} key={selectedIssue.id} />
-          )}
-        </AnimatePresence>
-      </motion.div>
-    </PanelContent>
+          <IssueCarousel
+            issues={issues}
+            loading={loading}
+            error={error}
+            selectedId={selectedIssue?.id}
+            onSelect={handleSelect}
+          />
+          <AnimatePresence mode="wait">
+            {!loading && selectedIssue && (
+              <IssueInfoPanel issue={selectedIssue} key={selectedIssue.id} />
+            )}
+          </AnimatePresence>
+        </motion.div>
+      </PanelContent>
+    </motion.div>
   );
 }

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -4,23 +4,31 @@ import { motion } from "framer-motion";
 
 export default function World() {
   return (
-    <PanelContent className="justify-start">
+    <motion.div
+      layoutId="panel-EXPLORE"
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      className="w-full h-full"
+    >
+      <PanelContent className="justify-start">
         <motion.section
           className="flex items-center justify-center hero-full"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-        <div className="flex items-center gap-4">
-          <BackButton />
-          <motion.h1
-            layoutId="EXPLORE"
-            className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-          >
-            EXPLORE
-          </motion.h1>
-        </div>
-      </motion.section>
-    </PanelContent>
+          <div className="flex items-center gap-4">
+            <BackButton />
+            <motion.h1
+              layoutId="EXPLORE"
+              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            >
+              EXPLORE
+            </motion.h1>
+          </div>
+        </motion.section>
+      </PanelContent>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- animate route changes using `AnimatePresence`
- tie panels and pages together with shared `layoutId`s for smooth expansion/shrink
- ensure back navigation participates in animations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b483c0d6dc8321912102721ff36509