### PR TITLE
refactor: centralize supabase media handling

### DIFF
--- a/src/hooks/useSupabaseMedia.js
+++ b/src/hooks/useSupabaseMedia.js
@@ -1,17 +1,5 @@
 import { useEffect, useState } from "react";
-import { createClient } from "@supabase/supabase-js";
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-const mediaBucket = import.meta.env.VITE_SUPABASE_MEDIA_BUCKET || "media";
-
-if (import.meta.env.DEV) {
-  console.log("Supabase URL:", supabaseUrl);
-  console.log("Supabase anon key (first 6 chars):", supabaseKey?.slice(0, 6));
-  console.log("Supabase media bucket:", mediaBucket);
-}
-
-const supabase = createClient(supabaseUrl, supabaseKey);
+import { supabase, fetchMediaList, uploadMedia as uploadMediaHelper } from "../api/supabase";
 
 export default function useSupabaseMedia() {
   const [media, setMedia] = useState([]);
@@ -22,27 +10,18 @@ export default function useSupabaseMedia() {
     setLoading(true);
     setError(null);
     try {
-      const { data, error: listError } = await supabase.storage
-        .from(mediaBucket)
-        .list();
-      if (listError) throw listError;
-
+      const data = await fetchMediaList();
       const items = await Promise.all(
         (data || []).map(async (item) => {
-          const { data: publicData } = supabase.storage
-            .from(mediaBucket)
-            .getPublicUrl(item.name);
-          const url = publicData?.publicUrl || "";
-          return {
-            id: item.id || item.name,
-            title: { rendered: item.name },
-            media_details: { sizes: { medium: { source_url: url } } },
-            source_url: url,
-            caption: { rendered: "" },
-          };
+          if (!item?.source_url && item?.path) {
+            const { data: publicData } = supabase.storage
+              .from("media")
+              .getPublicUrl(item.path);
+            return { ...item, source_url: publicData?.publicUrl || "" };
+          }
+          return item;
         })
       );
-
       setMedia(items);
     } catch (err) {
       setError(err);
@@ -52,17 +31,7 @@ export default function useSupabaseMedia() {
   };
 
   const uploadMedia = async (file) => {
-    const filePath = `${Date.now()}-${file.name}`;
-    const { error: uploadError } = await supabase.storage
-      .from(mediaBucket)
-      .upload(filePath, file);
-    if (uploadError) throw uploadError;
-
-    const { data: publicData } = supabase.storage
-      .from(mediaBucket)
-      .getPublicUrl(filePath);
-    const url = publicData?.publicUrl || "";
-    return { id: filePath, url };
+    return uploadMediaHelper(file);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- streamline `useSupabaseMedia` by reusing shared Supabase helpers
- remove local client creation and env variable handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b487fda6f8832188426e271e8dc3b0