### PR TITLE
feat: add global media store

### DIFF
--- a/src/components/MediaManager.jsx
+++ b/src/components/MediaManager.jsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import useSupabaseMedia from '../hooks/useSupabaseMedia';
+import { useMediaStore } from '../hooks/useMediaStore';
 
 export default function MediaManager() {
   const [file, setFile] = useState(null);
   const [status, setStatus] = useState('');
-  const { uploadMedia } = useSupabaseMedia();
+  const { uploadMedia } = useMediaStore();
 
   const handleUpload = async () => {
     if (!file) return;

--- a/src/components/TeamCarousel.jsx
+++ b/src/components/TeamCarousel.jsx
@@ -1,9 +1,9 @@
-import useSupabaseMedia from "../hooks/useSupabaseMedia";
+import { useMediaStore } from "../hooks/useMediaStore";
 import ImageWithFallback from "./ImageWithFallback";
 import { motion } from "framer-motion";
 
 export default function TeamCarousel({ selectedId, onSelect }) {
-  const { media, loading, error } = useSupabaseMedia();
+  const { media, loading, error } = useMediaStore();
   const hideLabels = selectedId !== null;
 
   if (loading) {

--- a/src/components/TeamInfoPanel.jsx
+++ b/src/components/TeamInfoPanel.jsx
@@ -1,9 +1,9 @@
 import { motion } from "framer-motion";
-import useSupabaseMedia from "../hooks/useSupabaseMedia";
+import { useMediaStore } from "../hooks/useMediaStore";
 import ImageWithFallback from "./ImageWithFallback";
 
 export default function TeamInfoPanel({ memberId }) {
-  const { media, loading, error } = useSupabaseMedia();
+  const { media, loading, error } = useMediaStore();
 
   if (loading) {
     return <div>Loading...</div>;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,14 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import { MediaProvider } from "./hooks/useMediaStore";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <MediaProvider>
+        <App />
+      </MediaProvider>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- introduce MediaProvider and useMediaStore to cache Supabase media and handle uploads
- update team components and media manager to consume shared store
- wrap app in MediaProvider for single fetch

## Testing
- npm test (fails: Missing script "test")
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68b488121a7c8321bc9dabd28758415d