### PR TITLE
refactor: use explicit Supabase column lists and ordering

### DIFF
--- a/src/api/supabase.js
+++ b/src/api/supabase.js
@@ -14,7 +14,12 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 export async function fetchIssues() {
   logRequest('Fetching issues from Supabase');
   try {
-    const { data, error } = await supabase.from('issues').select('*');
+    const { data, error } = await supabase
+      .from('issues')
+      .select(
+        'id, title, number, cover_image, release_date, short_description, long_description, subtitle, writer, artist, colorist'
+      )
+      .order('number', { ascending: true });
     if (error) {
       logError('Error fetching issues from Supabase', error);
       throw error;
@@ -30,7 +35,9 @@ export async function fetchIssues() {
 export async function fetchHomePanels() {
   logRequest('Fetching home panels from Supabase');
   try {
-    const { data, error } = await supabase.from('home_panels').select('*');
+    const { data, error } = await supabase
+      .from('home_panels')
+      .select('id, image_url');
     if (error) {
       logError('Error fetching home panels', error);
       throw error;
@@ -48,7 +55,7 @@ export async function fetchPageSubtitle(id) {
   try {
     const { data, error } = await supabase
       .from('page_subtitles')
-      .select('*')
+      .select('id, headline_content')
       .eq('id', id)
       .single();
     if (error) {
@@ -66,7 +73,9 @@ export async function fetchPageSubtitle(id) {
 export async function fetchMediaList() {
   logRequest('Fetching media list from Supabase');
   try {
-    const { data, error } = await supabase.from('media').select('*');
+    const { data, error } = await supabase
+      .from('media')
+      .select('id, title, url, caption');
     if (error) {
       logError('Error fetching media list', error);
       throw error;

--- a/src/hooks/useSupabaseIssues.js
+++ b/src/hooks/useSupabaseIssues.js
@@ -11,18 +11,8 @@ export default function useSupabaseIssues() {
     setError(null);
     try {
       const data = await fetchIssues();
-
-      // Sort by issue number if possible
-      const sorted = [...data].sort((a, b) => {
-        const aVal = Number(a.number);
-        const bVal = Number(b.number);
-        const aNum = Number.isFinite(aVal) ? aVal : Infinity;
-        const bNum = Number.isFinite(bVal) ? bVal : Infinity;
-        return aNum - bNum;
-      });
-
       // Normalize issue shape
-      const mapped = sorted.map((item) => ({
+      const mapped = data.map((item) => ({
         id: item.id,
         title: item.title,
         number: item.number,


### PR DESCRIPTION
## Summary
- explicitly select columns for Supabase `issues`, `home_panels`, `page_subtitles`, and `media` tables
- order issues in the database and drop client-side sorting

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4880a62d08321958ced186af2fc3c