### PR TITLE
Center hero headers and reduce padding

### DIFF
--- a/src/components/BackButton.jsx
+++ b/src/components/BackButton.jsx
@@ -9,7 +9,7 @@ export default function BackButton() {
   if (isHome) {
     return null;
   }
-  const positionClasses = "fixed top-4 left-4 z-50";
+  const positionClasses = "fixed top-2 left-2 z-50";
   const baseClasses =
     "w-12 h-12 rounded-full border overflow-hidden transition-colors duration-200";
   const className = `${baseClasses} ${positionClasses}`;

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -15,25 +15,23 @@ export default function Buy() {
     >
       <PanelContent className="justify-start">
         <motion.section
-          className="relative flex flex-col items-center justify-center p-4 text-center hero-full"
+          className="relative flex flex-col items-center justify-center gap-4 p-2 text-center hero-full"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-          <div className="flex items-center gap-4">
-            <BackButton />
-            <motion.h1
-              layoutId="BUY"
-              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-            >
-              BUY
-            </motion.h1>
-          </div>
+          <BackButton />
+          <motion.h1
+            layoutId="BUY"
+            className="relative z-50 px-4 py-2 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          >
+            BUY
+          </motion.h1>
           <motion.p
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.3, delay: 0.1 }}
-            className="max-w-xl text-lg md:text-2xl mb-4"
+            className="max-w-xl text-lg md:text-2xl"
           >
             {headline}
           </motion.p>

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -42,21 +42,19 @@ export default function Connect() {
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-          <div className="relative flex flex-col items-center justify-center w-full h-full gap-4 p-4 text-center">
-            <div className="flex items-center gap-4">
-              <BackButton />
-              <motion.h1
-                layoutId="CONNECT"
-                className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-              >
-                CONNECT
-              </motion.h1>
-            </div>
+          <div className="relative flex flex-col items-center justify-center w-full h-full gap-4 p-2 text-center">
+            <BackButton />
+            <motion.h1
+              layoutId="CONNECT"
+              className="relative z-50 px-4 py-2 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+            >
+              CONNECT
+            </motion.h1>
             <motion.p
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.3, delay: 0.1 }}
-              className="max-w-xl text-lg md:text-2xl mb-4"
+              className="max-w-xl text-lg md:text-2xl"
             >
               {headline}
             </motion.p>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -30,17 +30,15 @@ export default function Meet() {
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-          <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
+          <div className="relative flex flex-col items-center justify-center w-full h-full p-2 text-center">
             <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
-              <div className="flex items-center gap-4">
-                <BackButton />
-                <motion.h1
-                  layoutId="MEET"
-                  className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-                >
-                  MEET
-                </motion.h1>
-              </div>
+              <BackButton />
+              <motion.h1
+                layoutId="MEET"
+                className="relative z-50 px-4 py-2 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              >
+                MEET
+              </motion.h1>
               <motion.p
                 initial={{ opacity: 0, x: 20 }}
                 animate={{ opacity: 1, x: 0 }}
@@ -63,7 +61,10 @@ export default function Meet() {
           <TeamCarousel selectedId={selectedMemberId} onSelect={handleSelect} />
           <AnimatePresence mode="wait">
             {selectedMemberId && (
-              <TeamInfoPanel memberId={selectedMemberId} key={selectedMemberId} />
+              <TeamInfoPanel
+                memberId={selectedMemberId}
+                key={selectedMemberId}
+              />
             )}
           </AnimatePresence>
         </motion.div>

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -50,17 +50,15 @@ export default function Read() {
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-          <div className="relative flex flex-col items-center justify-center w-full h-full p-4 text-center">
+          <div className="relative flex flex-col items-center justify-center w-full h-full p-2 text-center">
             <div className="flex flex-col items-center justify-center w-full gap-4 md:gap-8">
-              <div className="flex items-center gap-4">
-                <BackButton />
-                <motion.h1
-                  layoutId="READ"
-                  className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-                >
-                  READ
-                </motion.h1>
-              </div>
+              <BackButton />
+              <motion.h1
+                layoutId="READ"
+                className="relative z-50 px-4 py-2 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+              >
+                READ
+              </motion.h1>
               <motion.p
                 initial={{ opacity: 0, x: 20 }}
                 animate={{ opacity: 1, x: 0 }}

--- a/src/pages/World.jsx
+++ b/src/pages/World.jsx
@@ -18,15 +18,13 @@ export default function World() {
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.3 }}
         >
-          <div className="flex items-center gap-4">
-            <BackButton />
-            <motion.h1
-              layoutId="EXPLORE"
-              className="relative z-50 px-6 py-4 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-            >
-              EXPLORE
-            </motion.h1>
-          </div>
+          <BackButton />
+          <motion.h1
+            layoutId="EXPLORE"
+            className="relative z-50 px-4 py-2 font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+          >
+            EXPLORE
+          </motion.h1>
         </motion.section>
       </PanelContent>
     </motion.div>


### PR DESCRIPTION
## Summary
- center hero section headers and trim padding for a tighter layout
- move back button closer to the edges

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b489090e288321bbc3c1a200e93690