### PR TITLE
feat: use hero font on home page panel labels

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -25,7 +25,7 @@ export default function PanelCard({
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <motion.span
             layoutId={label}
-            className="text-black font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
+            className="text-black font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)] font-hero"
           >
             {label}
           </motion.span>


### PR DESCRIPTION
## Summary
- use `font-hero` so home page panel labels match subpage headings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b513f0320c8321a8ea3d8930d97287