### PR TITLE
Remove underline on breadcrumb hover

### DIFF
--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -21,7 +21,7 @@ export default function Breadcrumbs() {
         <span key={crumb.to} className="flex items-center">
           <Link
             to={crumb.to}
-            className="text-[var(--foreground)] hover:underline"
+            className="text-[var(--foreground)]"
           >
             {crumb.name}
           </Link>


### PR DESCRIPTION
## Summary
- remove hover underline from breadcrumb links

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b516e9dae083219b1127ad84858b76