### PR TITLE
Fade in inactive panels when returning home

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,8 @@
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { LayoutGroup, AnimatePresence } from "framer-motion";
+import { useEffect } from "react";
+
+import { updatePreviousPathname } from "./utils/navigation";
 
 import PanelGrid from "./components/PanelGrid";
 import Read from "./pages/Read";
@@ -10,6 +13,10 @@ import Breadcrumbs from "./components/Breadcrumbs";
 
 export default function App() {
   const location = useLocation();
+
+  useEffect(() => {
+    updatePreviousPathname(location.pathname);
+  }, [location.pathname]);
 
   return (
     <div className="fixed inset-0 overflow-hidden p-3 bg-[#fdfaf5]">

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -7,11 +7,17 @@ export default function PanelCard({
   imageSrc,
   label,
   to,
+  initial,
+  animate,
+  transition,
 }) {
   const content = (
     <motion.div
       layoutId={`panel-${label}`}
       whileHover={{ scale: 1.02 }}
+      initial={initial}
+      animate={animate}
+      transition={transition}
       className={`relative w-full h-full cursor-pointer border border-black rounded-lg overflow-hidden group bg-transparent flex items-center justify-center ${className}`}
     >
       {imageSrc && (

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,4 +1,5 @@
 import PanelCard from "./PanelCard";
+import { getPreviousPathname } from "../utils/navigation";
 
 const panels = [
   {
@@ -24,17 +25,32 @@ const panels = [
 ];
 
 export default function PanelGrid() {
+  const prevPath = getPreviousPathname();
+  const fromPanel = prevPath && prevPath !== "/" ? prevPath.slice(1).toUpperCase() : null;
+
   return (
     <div className="grid w-full h-full grid-cols-2 grid-rows-2 gap-4">
-      {panels.map((panel) => (
-        <PanelCard
-          key={panel.label}
-          className="w-full h-full"
-          imageSrc={panel.image}
-          label={panel.label}
-          to={panel.to}
-        />
-      ))}
+      {panels.map((panel) => {
+        const fadeProps =
+          fromPanel && panel.label !== fromPanel
+            ? {
+                initial: { opacity: 0 },
+                animate: { opacity: 1 },
+                transition: { duration: 0.4 },
+              }
+            : {};
+
+        return (
+          <PanelCard
+            key={panel.label}
+            className="w-full h-full"
+            imageSrc={panel.image}
+            label={panel.label}
+            to={panel.to}
+            {...fadeProps}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -1,0 +1,5 @@
+export let previousPathname = "/";
+export const updatePreviousPathname = (path) => {
+  previousPathname = path;
+};
+export const getPreviousPathname = () => previousPathname;


### PR DESCRIPTION
## Summary
- track previous route to detect when returning to home
- fade in non-active panels on home with framer-motion
- expose motion props on PanelCard for flexible animations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51922d8288321bc4a811f5670a21f