### PR TITLE
Remove duplicate breadcrumbs and align panel padding

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,14 +6,12 @@ import Read from "./pages/Read";
 import Buy from "./pages/Buy";
 import Meet from "./pages/Meet";
 import Connect from "./pages/Connect";
-import Breadcrumbs from "./components/Breadcrumbs";
 
 export default function App() {
   const location = useLocation();
 
   return (
     <div className="fixed inset-0 overflow-hidden p-3 bg-[#fdfaf5]">
-      <Breadcrumbs />
       <LayoutGroup>
         <AnimatePresence mode="wait">
           <Routes location={location} key={location.pathname}>

--- a/src/components/Panel.jsx
+++ b/src/components/Panel.jsx
@@ -7,7 +7,7 @@ export default function Panel({ id, children }) {
       layoutId={`panel-${id}`}
       className="w-full h-full border border-black rounded-lg overflow-hidden"
     >
-      <div className="h-full overflow-y-auto p-6 flex flex-col">
+      <div className="h-full overflow-y-auto flex flex-col px-6 pt-6 pb-6">
         <Breadcrumbs className="sticky top-6" />
         <div className="flex-1 flex items-center justify-center">{children}</div>
       </div>


### PR DESCRIPTION
## Summary
- remove extra breadcrumb navigation outside panels
- ensure panel content has equal padding on top and left

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b518c39940832199fda429801bd9df