### PR TITLE
feat: add SVG noise overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,17 @@
     <title>Renowned Site</title>
   </head>
   <body>
+    <svg style="display: none">
+      <filter id="noise">
+        <feTurbulence
+          type="fractalNoise"
+          baseFrequency="1.2"
+          numOctaves="3"
+          stitchTiles="stitch"
+        />
+        <feColorMatrix type="saturate" values="0" />
+      </filter>
+    </svg>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/index.css
+++ b/src/index.css
@@ -41,7 +41,18 @@ body {
   background-color: var(--background);
   color: var(--foreground);
   overflow: hidden;
+  position: relative;
   @apply font-sans;
+}
+
+body::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  filter: url(#noise);
+  opacity: 0.15;
+  mix-blend-mode: multiply;
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- overlay subtle film-like noise using hidden SVG filter
- blend procedural grain over page background with CSS pseudo-element

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5db5d5ed48321b0936a3e4cf32473