### PR TITLE
feat: show breadcrumb navigation on home page

### DIFF
--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -3,8 +3,6 @@ import { Link, useLocation } from "react-router-dom";
 export default function Breadcrumbs({ className = "" }) {
   const location = useLocation();
   const pathnames = location.pathname.split("/").filter(Boolean);
-
-  if (pathnames.length === 0) return null;
   const crumbs = [
     { name: "home", to: "/" },
     ...pathnames.map((segment, index) => {

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,4 +1,5 @@
 import PanelCard from "./PanelCard";
+import Breadcrumbs from "./Breadcrumbs";
 import { getPreviousPathname } from "../utils/navigation";
 
 const panels = [
@@ -29,28 +30,31 @@ export default function PanelGrid() {
   const fromPanel = prevPath && prevPath !== "/" ? prevPath.slice(1).toUpperCase() : null;
 
   return (
-    <div className="grid w-full h-full grid-cols-2 grid-rows-2 gap-4">
-      {panels.map((panel) => {
-        const fadeProps =
-          fromPanel && panel.label !== fromPanel
-            ? {
-                initial: { opacity: 0 },
-                animate: { opacity: 1 },
-                transition: { duration: 0.4 },
-              }
-            : {};
+    <div className="h-full flex flex-col px-6 pt-6 pb-6">
+      <Breadcrumbs className="mb-6" />
+      <div className="flex-1 grid w-full grid-cols-2 grid-rows-2 gap-4">
+        {panels.map((panel) => {
+          const fadeProps =
+            fromPanel && panel.label !== fromPanel
+              ? {
+                  initial: { opacity: 0 },
+                  animate: { opacity: 1 },
+                  transition: { duration: 0.4 },
+                }
+              : {};
 
-        return (
-          <PanelCard
-            key={panel.label}
-            className="w-full h-full"
-            imageSrc={panel.image}
-            label={panel.label}
-            to={panel.to}
-            {...fadeProps}
-          />
-        );
-      })}
+          return (
+            <PanelCard
+              key={panel.label}
+              className="w-full h-full"
+              imageSrc={panel.image}
+              label={panel.label}
+              to={panel.to}
+              {...fadeProps}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- always render home breadcrumb and show nav on home page
- include breadcrumb navigation above home page panels

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b63a9a220c8321a4472d7452efc37e