### PR TITLE
Persist breadcrumb navigation and notch buy panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Read from "./pages/Read";
 import Buy from "./pages/Buy";
 import Meet from "./pages/Meet";
 import Connect from "./pages/Connect";
+import Breadcrumbs from "./components/Breadcrumbs";
 
 export default function App() {
   const location = useLocation();
@@ -19,6 +20,7 @@ export default function App() {
 
   return (
     <div className="fixed inset-0 overflow-hidden p-3 bg-[#fdfaf5]">
+      <Breadcrumbs className="absolute top-6 left-6 z-10" />
       <LayoutGroup>
         <AnimatePresence mode="wait">
           <Routes location={location} key={location.pathname}>

--- a/src/components/Panel.jsx
+++ b/src/components/Panel.jsx
@@ -1,5 +1,4 @@
 import { motion } from "framer-motion";
-import Breadcrumbs from "./Breadcrumbs";
 
 export default function Panel({ id, children }) {
   return (
@@ -7,8 +6,7 @@ export default function Panel({ id, children }) {
       layoutId={`panel-${id}`}
       className="w-full h-full border border-black rounded-lg overflow-hidden"
     >
-      <div className="h-full overflow-y-auto flex flex-col px-6 pt-6 pb-6">
-        <Breadcrumbs className="sticky top-6" />
+      <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6">
         <div className="flex-1 flex items-center justify-center">{children}</div>
       </div>
     </motion.div>

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -18,7 +18,7 @@ export default function PanelCard({
       initial={initial}
       animate={animate}
       transition={transition}
-      className={`relative w-full h-full cursor-pointer border border-black rounded-lg overflow-hidden group bg-transparent flex items-center justify-center ${className}`}
+        className={`relative w-full h-full cursor-pointer border border-black rounded-lg overflow-hidden group bg-transparent flex items-center justify-center ${label === "BUY" ? "buy-notch" : ""} ${className}`}
     >
       {imageSrc && (
         <ImageWithFallback

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,5 +1,4 @@
 import PanelCard from "./PanelCard";
-import Breadcrumbs from "./Breadcrumbs";
 import { getPreviousPathname } from "../utils/navigation";
 
 const panels = [
@@ -30,8 +29,7 @@ export default function PanelGrid() {
   const fromPanel = prevPath && prevPath !== "/" ? prevPath.slice(1).toUpperCase() : null;
 
   return (
-    <div className="h-full flex flex-col px-6 pt-6 pb-6">
-      <Breadcrumbs className="mb-6" />
+    <div className="h-full flex flex-col px-6 pt-10 pb-6">
       <div className="flex-1 grid w-full grid-cols-2 grid-rows-2 gap-4">
         {panels.map((panel) => {
           const fadeProps =

--- a/src/index.css
+++ b/src/index.css
@@ -64,3 +64,17 @@ body::before {
     @apply w-full h-[50vh] bg-gradient-to-b from-gray-400 to-white;
   }
 }
+
+/* Notch for BUY panel to accommodate persistent breadcrumbs */
+.buy-notch::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: #fdfaf5;
+  border-right: 1px solid black;
+  border-bottom: 1px solid black;
+  border-bottom-right-radius: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- Move breadcrumbs into top-level app layout so navigation stays persistent across all pages
- Adjust panels and grid spacing for new breadcrumb placement
- Add notch styling to BUY panel so its border wraps the breadcrumb area

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b63ea75e1c8321a20b5e44293a307a