### PR TITLE
Add placeholder admin dashboard route and template

### DIFF
--- a/admin-dashboard.php
+++ b/admin-dashboard.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Simple placeholder dashboard for the Mini CMS.
+ * Users must be logged in and have manage_options capability.
+ */
+
+if ( ! is_user_logged_in() ) {
+    auth_redirect();
+}
+
+if ( ! current_user_can( 'manage_options' ) ) {
+    wp_die( __( 'You do not have permission to access this page.' ) );
+}
+
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>" />
+    <title><?php esc_html_e( 'Mini CMS Dashboard', 'renowned' ); ?></title>
+    <?php wp_head(); ?>
+</head>
+<body>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Mini CMS Dashboard', 'renowned' ); ?></h1>
+    <form method="post">
+        <?php wp_nonce_field( 'rh_mini_cms_save', 'rh_mini_cms_nonce' ); ?>
+        <p>
+            <label for="subtitle"><?php esc_html_e( 'Subtitle', 'renowned' ); ?></label><br />
+            <input type="text" id="subtitle" name="subtitle" class="regular-text" />
+        </p>
+        <p>
+            <label for="description"><?php esc_html_e( 'Description', 'renowned' ); ?></label><br />
+            <textarea id="description" name="description" class="large-text" rows="5"></textarea>
+        </p>
+        <p>
+            <label for="image_url"><?php esc_html_e( 'Image URL', 'renowned' ); ?></label><br />
+            <input type="text" id="image_url" name="image_url" class="regular-text" />
+        </p>
+        <?php submit_button(); ?>
+    </form>
+</div>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/functions.php
+++ b/functions.php
@@ -116,3 +116,45 @@ add_action( 'rest_api_init', function() {
         },
     ] );
 } );
+
+/**
+ * Register a front-end route at /admin for the Mini CMS dashboard.
+ */
+function rh_register_admin_route() {
+    add_rewrite_rule( '^admin/?$', 'index.php?rh_admin_dashboard=1', 'top' );
+}
+add_action( 'init', 'rh_register_admin_route' );
+
+/**
+ * Add custom query var for the admin dashboard.
+ *
+ * @param array $vars Existing query vars.
+ * @return array Modified query vars.
+ */
+function rh_admin_query_var( $vars ) {
+    $vars[] = 'rh_admin_dashboard';
+    return $vars;
+}
+add_filter( 'query_vars', 'rh_admin_query_var' );
+
+/**
+ * Load the dashboard template when /admin is requested.
+ *
+ * @param string $template The path to the template to include.
+ * @return string Path to dashboard template or original.
+ */
+function rh_admin_template_include( $template ) {
+    if ( get_query_var( 'rh_admin_dashboard' ) ) {
+        return __DIR__ . '/admin-dashboard.php';
+    }
+
+    return $template;
+}
+add_filter( 'template_include', 'rh_admin_template_include' );
+
+// Ensure rewrite rules are flushed when the theme is switched.
+function rh_flush_admin_rewrite() {
+    rh_register_admin_route();
+    flush_rewrite_rules();
+}
+add_action( 'after_switch_theme', 'rh_flush_admin_rewrite' );


### PR DESCRIPTION
## Summary
- expose `/admin` front-end route for a Mini CMS dashboard
- add placeholder form fields for subtitle, description and image URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b79bbc0c608321ae04a2ecbb0329af