### PR TITLE
Remove notch from BUY panel

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -17,8 +17,8 @@ export default function PanelCard({
       whileHover={{ scale: 1.02 }}
       initial={initial}
       animate={animate}
-      transition={transition}
-        className={`relative w-full h-full cursor-pointer border border-black rounded-lg overflow-hidden group bg-transparent flex items-center justify-center ${label === "BUY" ? "buy-notch" : ""} ${className}`}
+        transition={transition}
+        className={`relative w-full h-full cursor-pointer border border-black rounded-lg overflow-hidden group bg-transparent flex items-center justify-center ${className}`}
     >
       {imageSrc && (
         <ImageWithFallback

--- a/src/index.css
+++ b/src/index.css
@@ -65,16 +65,3 @@ body::before {
   }
 }
 
-/* Notch for BUY panel to accommodate persistent breadcrumbs */
-.buy-notch::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 2.5rem;
-  height: 2.5rem;
-  background: #fdfaf5;
-  border-right: 1px solid black;
-  border-bottom: 1px solid black;
-  border-bottom-right-radius: 0.5rem;
-}


### PR DESCRIPTION
## Summary
- Eliminate special notch styling for the BUY panel by removing the `buy-notch` pseudo-element.
- Simplify `PanelCard` by dropping conditional `buy-notch` class usage.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b79769e9bc8321bed81383f6466e99