### PR TITLE
Add structured page content JSON files

### DIFF
--- a/content/buy.json
+++ b/content/buy.json
@@ -1,0 +1,14 @@
+{
+  "panel": {
+    "main": {
+      "id": "BUY"
+    }
+  },
+  "hero": {
+    "heading": {
+      "layoutId": "BUY",
+      "text": "BUY",
+      "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+    }
+  }
+}

--- a/content/connect.json
+++ b/content/connect.json
@@ -1,0 +1,14 @@
+{
+  "panel": {
+    "main": {
+      "id": "CONNECT"
+    }
+  },
+  "hero": {
+    "heading": {
+      "layoutId": "CONNECT",
+      "text": "CONNECT",
+      "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+    }
+  }
+}

--- a/content/meet.json
+++ b/content/meet.json
@@ -1,0 +1,14 @@
+{
+  "panel": {
+    "main": {
+      "id": "MEET"
+    }
+  },
+  "hero": {
+    "heading": {
+      "layoutId": "MEET",
+      "text": "MEET",
+      "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+    }
+  }
+}

--- a/content/read.json
+++ b/content/read.json
@@ -1,0 +1,14 @@
+{
+  "panel": {
+    "main": {
+      "id": "READ"
+    }
+  },
+  "hero": {
+    "heading": {
+      "layoutId": "READ",
+      "text": "READ",
+      "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a `content` directory to hold page content
- draft JSON files for Buy, Connect, Meet, and Read pages using a section-component-element convention

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7a34c56c88321a5bf547fb262fc6f