### PR TITLE
Load page content from runtime JSON files

### DIFF
--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,14 +1,28 @@
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import { fetchJson } from "../utils/fetchJson";
 
 export default function Buy() {
+  const [content, setContent] = useState(null);
+
+  useEffect(() => {
+    fetchJson("/content/buy.json").then(setContent);
+  }, []);
+
+  if (!content) {
+    return null;
+  }
+
+  const {
+    panel,
+    hero: { heading },
+  } = content;
+
   return (
-    <Panel id="BUY">
-      <motion.h1
-        layoutId="BUY"
-        className="text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-      >
-        BUY
+    <Panel id={panel.main.id}>
+      <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+        {heading.text}
       </motion.h1>
     </Panel>
   );

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -1,14 +1,28 @@
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import { fetchJson } from "../utils/fetchJson";
 
 export default function Connect() {
+  const [content, setContent] = useState(null);
+
+  useEffect(() => {
+    fetchJson("/content/connect.json").then(setContent);
+  }, []);
+
+  if (!content) {
+    return null;
+  }
+
+  const {
+    panel,
+    hero: { heading },
+  } = content;
+
   return (
-    <Panel id="CONNECT">
-      <motion.h1
-        layoutId="CONNECT"
-        className="text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-      >
-        CONNECT
+    <Panel id={panel.main.id}>
+      <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+        {heading.text}
       </motion.h1>
     </Panel>
   );

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -1,14 +1,28 @@
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import { fetchJson } from "../utils/fetchJson";
 
 export default function Meet() {
+  const [content, setContent] = useState(null);
+
+  useEffect(() => {
+    fetchJson("/content/meet.json").then(setContent);
+  }, []);
+
+  if (!content) {
+    return null;
+  }
+
+  const {
+    panel,
+    hero: { heading },
+  } = content;
+
   return (
-    <Panel id="MEET">
-      <motion.h1
-        layoutId="MEET"
-        className="text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-      >
-        MEET
+    <Panel id={panel.main.id}>
+      <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+        {heading.text}
       </motion.h1>
     </Panel>
   );

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,14 +1,28 @@
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import { fetchJson } from "../utils/fetchJson";
 
 export default function Read() {
+  const [content, setContent] = useState(null);
+
+  useEffect(() => {
+    fetchJson("/content/read.json").then(setContent);
+  }, []);
+
+  if (!content) {
+    return null;
+  }
+
+  const {
+    panel,
+    hero: { heading },
+  } = content;
+
   return (
-    <Panel id="READ">
-      <motion.h1
-        layoutId="READ"
-        className="text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-      >
-        READ
+    <Panel id={panel.main.id}>
+      <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+        {heading.text}
       </motion.h1>
     </Panel>
   );

--- a/src/utils/fetchJson.js
+++ b/src/utils/fetchJson.js
@@ -1,0 +1,17 @@
+import { logError, logRequest, logSuccess } from "./logger";
+
+export async function fetchJson(path) {
+  try {
+    logRequest("Fetching JSON", { path });
+    const response = await fetch(path);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${path}: ${response.status}`);
+    }
+    const data = await response.json();
+    logSuccess("Fetched JSON", { path });
+    return data;
+  } catch (error) {
+    logError(`fetchJson ${path}`, error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add utility for fetching and parsing JSON files at runtime
- populate Buy, Connect, Meet, and Read pages with data from JSON content files

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7a40120988321836d7b28a918b377