### PR TITLE
feat: support local hero images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ pnpm-debug.log*
 
 # Optional: Tailwind JIT cache
 /.tailwind-cache
+
+# uploads
+public/uploads/*
+!public/uploads/.gitkeep

--- a/content/buy.json
+++ b/content/buy.json
@@ -9,6 +9,7 @@
       "layoutId": "BUY",
       "text": "BUY",
       "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   }
 }

--- a/content/connect.json
+++ b/content/connect.json
@@ -9,6 +9,7 @@
       "layoutId": "CONNECT",
       "text": "CONNECT",
       "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   }
 }

--- a/content/meet.json
+++ b/content/meet.json
@@ -9,6 +9,7 @@
       "layoutId": "MEET",
       "text": "MEET",
       "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   }
 }

--- a/content/read.json
+++ b/content/read.json
@@ -9,6 +9,7 @@
       "layoutId": "READ",
       "text": "READ",
       "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   }
 }

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import ImageWithFallback from "../components/ImageWithFallback";
 import { fetchJson } from "../utils/fetchJson";
 
 export default function Buy() {
@@ -16,14 +17,23 @@ export default function Buy() {
 
   const {
     panel,
-    hero: { heading },
+    hero: { heading, image },
   } = content;
 
   return (
     <Panel id={panel.main.id}>
-      <motion.h1 layoutId={heading.layoutId} className={heading.className}>
-        {heading.text}
-      </motion.h1>
+      <div className="flex flex-col items-center">
+        <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+          {heading.text}
+        </motion.h1>
+        {image && (
+          <ImageWithFallback
+            src={image}
+            alt={heading.text}
+            className="mt-4 max-w-full"
+          />
+        )}
+      </div>
     </Panel>
   );
 }

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import ImageWithFallback from "../components/ImageWithFallback";
 import { fetchJson } from "../utils/fetchJson";
 
 export default function Connect() {
@@ -16,14 +17,23 @@ export default function Connect() {
 
   const {
     panel,
-    hero: { heading },
+    hero: { heading, image },
   } = content;
 
   return (
     <Panel id={panel.main.id}>
-      <motion.h1 layoutId={heading.layoutId} className={heading.className}>
-        {heading.text}
-      </motion.h1>
+      <div className="flex flex-col items-center">
+        <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+          {heading.text}
+        </motion.h1>
+        {image && (
+          <ImageWithFallback
+            src={image}
+            alt={heading.text}
+            className="mt-4 max-w-full"
+          />
+        )}
+      </div>
     </Panel>
   );
 }

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import ImageWithFallback from "../components/ImageWithFallback";
 import { fetchJson } from "../utils/fetchJson";
 
 export default function Meet() {
@@ -16,14 +17,23 @@ export default function Meet() {
 
   const {
     panel,
-    hero: { heading },
+    hero: { heading, image },
   } = content;
 
   return (
     <Panel id={panel.main.id}>
-      <motion.h1 layoutId={heading.layoutId} className={heading.className}>
-        {heading.text}
-      </motion.h1>
+      <div className="flex flex-col items-center">
+        <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+          {heading.text}
+        </motion.h1>
+        {image && (
+          <ImageWithFallback
+            src={image}
+            alt={heading.text}
+            className="mt-4 max-w-full"
+          />
+        )}
+      </div>
     </Panel>
   );
 }

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import ImageWithFallback from "../components/ImageWithFallback";
 import { fetchJson } from "../utils/fetchJson";
 
 export default function Read() {
@@ -16,14 +17,23 @@ export default function Read() {
 
   const {
     panel,
-    hero: { heading },
+    hero: { heading, image },
   } = content;
 
   return (
     <Panel id={panel.main.id}>
-      <motion.h1 layoutId={heading.layoutId} className={heading.className}>
-        {heading.text}
-      </motion.h1>
+      <div className="flex flex-col items-center">
+        <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+          {heading.text}
+        </motion.h1>
+        {image && (
+          <ImageWithFallback
+            src={image}
+            alt={heading.text}
+            className="mt-4 max-w-full"
+          />
+        )}
+      </div>
     </Panel>
   );
 }


### PR DESCRIPTION
## Summary
- add public uploads directory with placeholder path support for hero images
- allow page content JSON to specify hero image URLs and render via `ImageWithFallback`
- ignore uploaded image files while keeping an empty `uploads` directory

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7a4bbaed48321b46ccfb18a846186