### PR TITLE
fix: use hero font for panel labels

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -30,7 +30,7 @@ export default function PanelCard({
       {label && (
         <motion.span
           layoutId={label}
-          className="pointer-events-none text-black font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
+          className="pointer-events-none text-black font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
         >
           {label}
         </motion.span>


### PR DESCRIPTION
## Summary
- apply `font-hero` utility to PanelCard label span to ensure hero typeface

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b797921acc8321a875a10db386f537