### PR TITLE
fix: restore panel transitions and heading size

### DIFF
--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,20 +1,9 @@
-import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
 import ImageWithFallback from "../components/ImageWithFallback";
-import { fetchJson } from "../utils/fetchJson";
+import content from "../../content/buy.json";
 
 export default function Buy() {
-  const [content, setContent] = useState(null);
-
-  useEffect(() => {
-    fetchJson("/content/buy.json").then(setContent);
-  }, []);
-
-  if (!content) {
-    return null;
-  }
-
   const {
     panel,
     hero: { heading, image },

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -1,20 +1,9 @@
-import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
 import ImageWithFallback from "../components/ImageWithFallback";
-import { fetchJson } from "../utils/fetchJson";
+import content from "../../content/connect.json";
 
 export default function Connect() {
-  const [content, setContent] = useState(null);
-
-  useEffect(() => {
-    fetchJson("/content/connect.json").then(setContent);
-  }, []);
-
-  if (!content) {
-    return null;
-  }
-
   const {
     panel,
     hero: { heading, image },

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -1,20 +1,9 @@
-import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
 import ImageWithFallback from "../components/ImageWithFallback";
-import { fetchJson } from "../utils/fetchJson";
+import content from "../../content/meet.json";
 
 export default function Meet() {
-  const [content, setContent] = useState(null);
-
-  useEffect(() => {
-    fetchJson("/content/meet.json").then(setContent);
-  }, []);
-
-  if (!content) {
-    return null;
-  }
-
   const {
     panel,
     hero: { heading, image },

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,20 +1,9 @@
-import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
 import ImageWithFallback from "../components/ImageWithFallback";
-import { fetchJson } from "../utils/fetchJson";
+import content from "../../content/read.json";
 
 export default function Read() {
-  const [content, setContent] = useState(null);
-
-  useEffect(() => {
-    fetchJson("/content/read.json").then(setContent);
-  }, []);
-
-  if (!content) {
-    return null;
-  }
-
   const {
     panel,
     hero: { heading, image },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,11 @@ import forms from "@tailwindcss/forms";
 
 export default {
   darkMode: "class",
-  content: ["./public/index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  content: [
+    "./public/index.html",
+    "./src/**/*.{js,jsx,ts,tsx}",
+    "./content/**/*.json",
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- include content JSON in Tailwind scan so heading styles render
- import page content statically to restore panel transitions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7bccbeb58832181dba49cef286832