### PR TITLE
feat: add editable subtitles

### DIFF
--- a/content/buy.json
+++ b/content/buy.json
@@ -10,6 +10,10 @@
       "text": "BUY",
       "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
     },
+    "subtitle": {
+      "text": "",
+      "className": "mt-2 text-center text-sm font-sans"
+    },
     "image": "/uploads/placeholder.png"
   }
 }

--- a/content/connect.json
+++ b/content/connect.json
@@ -10,6 +10,10 @@
       "text": "CONNECT",
       "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
     },
+    "subtitle": {
+      "text": "",
+      "className": "mt-2 text-center text-sm font-sans"
+    },
     "image": "/uploads/placeholder.png"
   }
 }

--- a/content/meet.json
+++ b/content/meet.json
@@ -10,6 +10,10 @@
       "text": "MEET",
       "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
     },
+    "subtitle": {
+      "text": "",
+      "className": "mt-2 text-center text-sm font-sans"
+    },
     "image": "/uploads/placeholder.png"
   }
 }

--- a/content/read.json
+++ b/content/read.json
@@ -10,6 +10,10 @@
       "text": "READ",
       "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
     },
+    "subtitle": {
+      "text": "",
+      "className": "mt-2 text-center text-sm font-sans"
+    },
     "image": "/uploads/placeholder.png"
   }
 }

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -17,7 +17,7 @@ export default function Buy() {
 
   const {
     panel,
-    hero: { heading, image },
+    hero: { heading, subtitle, image },
   } = content;
 
   return (
@@ -26,6 +26,9 @@ export default function Buy() {
         <motion.h1 layoutId={heading.layoutId} className={heading.className}>
           {heading.text}
         </motion.h1>
+        {subtitle?.text && (
+          <p className={subtitle.className}>{subtitle.text}</p>
+        )}
         {image && (
           <ImageWithFallback
             src={image}

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -17,7 +17,7 @@ export default function Connect() {
 
   const {
     panel,
-    hero: { heading, image },
+    hero: { heading, subtitle, image },
   } = content;
 
   return (
@@ -26,6 +26,9 @@ export default function Connect() {
         <motion.h1 layoutId={heading.layoutId} className={heading.className}>
           {heading.text}
         </motion.h1>
+        {subtitle?.text && (
+          <p className={subtitle.className}>{subtitle.text}</p>
+        )}
         {image && (
           <ImageWithFallback
             src={image}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -17,7 +17,7 @@ export default function Meet() {
 
   const {
     panel,
-    hero: { heading, image },
+    hero: { heading, subtitle, image },
   } = content;
 
   return (
@@ -26,6 +26,9 @@ export default function Meet() {
         <motion.h1 layoutId={heading.layoutId} className={heading.className}>
           {heading.text}
         </motion.h1>
+        {subtitle?.text && (
+          <p className={subtitle.className}>{subtitle.text}</p>
+        )}
         {image && (
           <ImageWithFallback
             src={image}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -17,7 +17,7 @@ export default function Read() {
 
   const {
     panel,
-    hero: { heading, image },
+    hero: { heading, subtitle, image },
   } = content;
 
   return (
@@ -26,6 +26,9 @@ export default function Read() {
         <motion.h1 layoutId={heading.layoutId} className={heading.className}>
           {heading.text}
         </motion.h1>
+        {subtitle?.text && (
+          <p className={subtitle.className}>{subtitle.text}</p>
+        )}
         {image && (
           <ImageWithFallback
             src={image}


### PR DESCRIPTION
## Summary
- allow each subpage to define a subtitle in its content JSON
- render small centered subtitle under each page's header with secondary font

## Testing
- `npm test` (fails: missing script: test)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7bd095938832187df1fb9013933d9