### PR TITLE
feat: add configurable button to buy page

### DIFF
--- a/content/buy.json
+++ b/content/buy.json
@@ -14,6 +14,11 @@
       "text": "",
       "className": "mt-2 text-center text-sm font-sans"
     },
+    "button": {
+      "url": "https://www.kickstarter.com/",
+      "defaultText": "Kickstarter",
+      "hoverText": "Follow Now!"
+    },
     "image": "/uploads/placeholder.png"
   }
 }

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -6,7 +6,7 @@ import content from "../../content/buy.json";
 export default function Buy() {
   const {
     panel,
-    hero: { heading, subtitle, image },
+    hero: { heading, subtitle, image, button },
   } = content;
 
   return (
@@ -17,6 +17,21 @@ export default function Buy() {
         </motion.h1>
         {subtitle?.text && (
           <p className={subtitle.className}>{subtitle.text}</p>
+        )}
+        {button && (
+          <a
+            href={button.url}
+            className="mt-4 group relative inline-block bg-black text-white px-6 py-3 overflow-hidden [perspective:1000px]"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="block transition-transform duration-300 [transform-origin:top] group-hover:[transform:rotateX(90deg)]">
+              {button.defaultText}
+            </span>
+            <span className="absolute inset-0 block transition-transform duration-300 [transform-origin:bottom] [transform:rotateX(-90deg)] group-hover:[transform:rotateX(0deg)]">
+              {button.hoverText}
+            </span>
+          </a>
         )}
         {image && (
           <ImageWithFallback


### PR DESCRIPTION
## Summary
- add admin-configurable Kickstarter button to Buy page
- default/hover text and URL stored in content schema

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7be65e488832197d44bffb902812b