### PR TITLE
feat: add text size control with reset in admin

### DIFF
--- a/content/buy.json
+++ b/content/buy.json
@@ -4,19 +4,21 @@
       "id": "BUY"
     }
   },
-  "hero": {
-    "heading": {
-      "layoutId": "BUY",
-      "text": "BUY",
-      "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-    },
-    "subtitle": {
-      "text": "",
-      "className": "mt-2 text-center text-8xl font-sans"
-    },
-    "button": {
-      "url": "https://www.kickstarter.com/",
-      "defaultText": "Kickstarter",
+    "hero": {
+      "heading": {
+        "layoutId": "BUY",
+        "text": "BUY",
+      "className": "text-black font-bold uppercase",
+      "size": "text-[clamp(3rem,8vw,10rem)]"
+      },
+      "subtitle": {
+        "text": "",
+      "className": "mt-2 text-center font-sans",
+      "size": "text-8xl"
+      },
+      "button": {
+        "url": "https://www.kickstarter.com/",
+        "defaultText": "Kickstarter",
       "hoverText": "Follow Now!"
     },
     "image": "/uploads/placeholder.png"

--- a/content/connect.json
+++ b/content/connect.json
@@ -4,16 +4,18 @@
       "id": "CONNECT"
     }
   },
-  "hero": {
-    "heading": {
-      "layoutId": "CONNECT",
-      "text": "CONNECT",
-      "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-    },
-    "subtitle": {
-      "text": "",
-      "className": "mt-2 text-center text-8xl font-sans"
-    },
-    "image": "/uploads/placeholder.png"
+    "hero": {
+      "heading": {
+        "layoutId": "CONNECT",
+        "text": "CONNECT",
+      "className": "text-black font-bold uppercase",
+      "size": "text-[clamp(3rem,8vw,10rem)]"
+      },
+      "subtitle": {
+        "text": "",
+      "className": "mt-2 text-center font-sans",
+      "size": "text-8xl"
+      },
+      "image": "/uploads/placeholder.png"
+    }
   }
-}

--- a/content/meet.json
+++ b/content/meet.json
@@ -4,16 +4,18 @@
       "id": "MEET"
     }
   },
-  "hero": {
-    "heading": {
-      "layoutId": "MEET",
-      "text": "MEET",
-      "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-    },
-    "subtitle": {
-      "text": "",
-      "className": "mt-2 text-center text-8xl font-sans"
-    },
-    "image": "/uploads/placeholder.png"
+    "hero": {
+      "heading": {
+        "layoutId": "MEET",
+        "text": "MEET",
+      "className": "text-black font-bold uppercase",
+      "size": "text-[clamp(3rem,8vw,10rem)]"
+      },
+      "subtitle": {
+        "text": "",
+      "className": "mt-2 text-center font-sans",
+      "size": "text-8xl"
+      },
+      "image": "/uploads/placeholder.png"
+    }
   }
-}

--- a/content/read.json
+++ b/content/read.json
@@ -4,16 +4,18 @@
       "id": "READ"
     }
   },
-  "hero": {
-    "heading": {
-      "layoutId": "READ",
-      "text": "READ",
-      "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
-    },
-    "subtitle": {
-      "text": "",
-      "className": "mt-2 text-center text-8xl font-sans"
-    },
-    "image": "/uploads/placeholder.png"
+    "hero": {
+      "heading": {
+        "layoutId": "READ",
+        "text": "READ",
+      "className": "text-black font-bold uppercase",
+      "size": "text-[clamp(3rem,8vw,10rem)]"
+      },
+      "subtitle": {
+        "text": "",
+      "className": "mt-2 text-center font-sans",
+      "size": "text-8xl"
+      },
+      "image": "/uploads/placeholder.png"
+    }
   }
-}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -8,6 +8,23 @@ const PAGES = [
   { id: "connect", name: "Connect" },
 ];
 
+const SIZE_OPTIONS = [
+  "text-xs",
+  "text-sm",
+  "text-base",
+  "text-lg",
+  "text-xl",
+  "text-2xl",
+  "text-3xl",
+  "text-4xl",
+  "text-5xl",
+  "text-6xl",
+  "text-7xl",
+  "text-8xl",
+  "text-9xl",
+  "text-[clamp(3rem,8vw,10rem)]",
+];
+
 export default function Admin() {
   const [password, setPassword] = useState("");
   const [authorized, setAuthorized] = useState(
@@ -15,6 +32,7 @@ export default function Admin() {
   );
   const [selectedPage, setSelectedPage] = useState(null);
   const [formData, setFormData] = useState(null);
+  const [defaultData, setDefaultData] = useState(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
 
@@ -53,6 +71,7 @@ export default function Admin() {
   const loadPage = async (page) => {
     setSelectedPage(page);
     setFormData(null);
+    setDefaultData(null);
     try {
       const res = await fetch(`/api/pages/${page.id}`);
       if (!res.ok) {
@@ -61,6 +80,7 @@ export default function Admin() {
       }
       const data = await res.json();
       setFormData(data);
+      setDefaultData(structuredClone(data));
       setError(null);
     } catch (err) {
       console.error(err);
@@ -76,6 +96,26 @@ export default function Admin() {
         obj = obj[path[i]];
       }
       obj[path[path.length - 1]] = value;
+      return updated;
+    });
+  };
+
+  const getValueAtPath = (obj, path) => {
+    let val = obj;
+    for (const key of path) {
+      val = val[key];
+    }
+    return val;
+  };
+
+  const resetField = (path) => {
+    setFormData((prev) => {
+      const updated = structuredClone(prev);
+      let obj = updated;
+      for (let i = 0; i < path.length - 1; i += 1) {
+        obj = obj[path[i]];
+      }
+      obj[path[path.length - 1]] = getValueAtPath(defaultData, path);
       return updated;
     });
   };
@@ -178,16 +218,52 @@ export default function Admin() {
           </div>
         );
       }
+      if (path[path.length - 1] === 'size') {
+        return (
+          <div key={name} className="flex flex-col gap-1">
+            <label className="font-medium">{label}</label>
+            <div className="flex items-center gap-2">
+              <select
+                value={value}
+                onChange={handleChange}
+                className="border px-2 py-1 rounded"
+              >
+                {SIZE_OPTIONS.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => resetField(path)}
+                className="p-1 border rounded-full"
+              >
+                ↺
+              </button>
+            </div>
+          </div>
+        );
+      }
       if (isDate) {
         return (
           <div key={name} className="flex flex-col gap-1">
             <label className="font-medium">{label}</label>
-            <input
-              type="date"
-              value={value.slice(0, 10)}
-              onChange={handleChange}
-              className="border px-2 py-1 rounded"
-            />
+            <div className="flex items-center gap-2">
+              <input
+                type="date"
+                value={value.slice(0, 10)}
+                onChange={handleChange}
+                className="border px-2 py-1 rounded"
+              />
+              <button
+                type="button"
+                onClick={() => resetField(path)}
+                className="p-1 border rounded-full"
+              >
+                ↺
+              </button>
+            </div>
           </div>
         );
       }
@@ -195,23 +271,41 @@ export default function Admin() {
         return (
           <div key={name} className="flex flex-col gap-1">
             <label className="font-medium">{label}</label>
-            <textarea
-              value={value}
-              onChange={handleChange}
-              className="border px-2 py-1 rounded"
-            />
+            <div className="flex items-center gap-2">
+              <textarea
+                value={value}
+                onChange={handleChange}
+                className="border px-2 py-1 rounded flex-1"
+              />
+              <button
+                type="button"
+                onClick={() => resetField(path)}
+                className="p-1 border rounded-full"
+              >
+                ↺
+              </button>
+            </div>
           </div>
         );
       }
       return (
         <div key={name} className="flex flex-col gap-1">
           <label className="font-medium">{label}</label>
-          <input
-            type="text"
-            value={value}
-            onChange={handleChange}
-            className="border px-2 py-1 rounded"
-          />
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={value}
+              onChange={handleChange}
+              className="border px-2 py-1 rounded"
+            />
+            <button
+              type="button"
+              onClick={() => resetField(path)}
+              className="p-1 border rounded-full"
+            >
+              ↺
+            </button>
+          </div>
         </div>
       );
     }
@@ -219,12 +313,21 @@ export default function Admin() {
       return (
         <div key={name} className="flex flex-col gap-1">
           <label className="font-medium">{label}</label>
-          <input
-            type="number"
-            value={value}
-            onChange={handleChange}
-            className="border px-2 py-1 rounded"
-          />
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              value={value}
+              onChange={handleChange}
+              className="border px-2 py-1 rounded"
+            />
+            <button
+              type="button"
+              onClick={() => resetField(path)}
+              className="p-1 border rounded-full"
+            >
+              ↺
+            </button>
+          </div>
         </div>
       );
     }
@@ -232,7 +335,14 @@ export default function Admin() {
       return (
         <div key={name} className="flex items-center gap-2">
           <input type="checkbox" checked={value} onChange={handleChange} />
-          <label className="font-medium">{label}</label>
+          <label className="font-medium flex-1">{label}</label>
+          <button
+            type="button"
+            onClick={() => resetField(path)}
+            className="p-1 border rounded-full"
+          >
+            ↺
+          </button>
         </div>
       );
     }

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -12,11 +12,16 @@ export default function Buy() {
   return (
     <Panel id={panel.main.id}>
       <div className="flex flex-col items-center">
-        <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+        <motion.h1
+          layoutId={heading.layoutId}
+          className={`${heading.className} ${heading.size}`}
+        >
           {heading.text}
         </motion.h1>
         {subtitle?.text && (
-          <p className={subtitle.className}>{subtitle.text}</p>
+          <p className={`${subtitle.className} ${subtitle.size}`}>
+            {subtitle.text}
+          </p>
         )}
         {button && (
           <a

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -12,11 +12,16 @@ export default function Connect() {
   return (
     <Panel id={panel.main.id}>
       <div className="flex flex-col items-center">
-        <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+        <motion.h1
+          layoutId={heading.layoutId}
+          className={`${heading.className} ${heading.size}`}
+        >
           {heading.text}
         </motion.h1>
         {subtitle?.text && (
-          <p className={subtitle.className}>{subtitle.text}</p>
+          <p className={`${subtitle.className} ${subtitle.size}`}>
+            {subtitle.text}
+          </p>
         )}
         {image && (
           <ImageWithFallback

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -12,11 +12,16 @@ export default function Meet() {
   return (
     <Panel id={panel.main.id}>
       <div className="flex flex-col items-center">
-        <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+        <motion.h1
+          layoutId={heading.layoutId}
+          className={`${heading.className} ${heading.size}`}
+        >
           {heading.text}
         </motion.h1>
         {subtitle?.text && (
-          <p className={subtitle.className}>{subtitle.text}</p>
+          <p className={`${subtitle.className} ${subtitle.size}`}>
+            {subtitle.text}
+          </p>
         )}
         {image && (
           <ImageWithFallback

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -12,11 +12,16 @@ export default function Read() {
   return (
     <Panel id={panel.main.id}>
       <div className="flex flex-col items-center">
-        <motion.h1 layoutId={heading.layoutId} className={heading.className}>
+        <motion.h1
+          layoutId={heading.layoutId}
+          className={`${heading.className} ${heading.size}`}
+        >
           {heading.text}
         </motion.h1>
         {subtitle?.text && (
-          <p className={subtitle.className}>{subtitle.text}</p>
+          <p className={`${subtitle.className} ${subtitle.size}`}>
+            {subtitle.text}
+          </p>
         )}
         {image && (
           <ImageWithFallback


### PR DESCRIPTION
## Summary
- allow selecting text size for headings and subtitles
- add circular reset button to restore default values
- support `size` field in page content and rendering

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7c0ff54b48321a229af9110e9ba0b