### PR TITLE
Tighten hero spacing and make elements responsive

### DIFF
--- a/content/buy.json
+++ b/content/buy.json
@@ -12,7 +12,7 @@
     },
     "subtitle": {
       "text": "",
-      "className": "mt-2 text-center text-8xl font-sans"
+      "className": "mt-1 text-center text-[clamp(1rem,5vw,4rem)] font-sans"
     },
     "button": {
       "url": "https://www.kickstarter.com/",

--- a/content/connect.json
+++ b/content/connect.json
@@ -12,7 +12,7 @@
     },
     "subtitle": {
       "text": "",
-      "className": "mt-2 text-center text-8xl font-sans"
+      "className": "mt-1 text-center text-[clamp(1rem,5vw,4rem)] font-sans"
     },
     "image": "/uploads/placeholder.png"
   }

--- a/content/meet.json
+++ b/content/meet.json
@@ -12,7 +12,7 @@
     },
     "subtitle": {
       "text": "",
-      "className": "mt-2 text-center text-8xl font-sans"
+      "className": "mt-1 text-center text-[clamp(1rem,5vw,4rem)] font-sans"
     },
     "image": "/uploads/placeholder.png"
   }

--- a/content/read.json
+++ b/content/read.json
@@ -12,7 +12,7 @@
     },
     "subtitle": {
       "text": "",
-      "className": "mt-2 text-center text-8xl font-sans"
+      "className": "mt-1 text-center text-[clamp(1rem,5vw,4rem)] font-sans"
     },
     "image": "/uploads/placeholder.png"
   }

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,10 @@
   --border: #e2e8f0;
 }
 
+html {
+  font-size: clamp(14px, 1.5vw, 18px);
+}
+
 html,
 body,
 #root {

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -21,7 +21,7 @@ export default function Buy() {
         {button && (
           <a
             href={button.url}
-            className="mt-4 group relative inline-block bg-black text-white px-6 py-3 overflow-hidden [perspective:1000px]"
+            className="mt-4 group relative inline-block bg-black text-white px-[clamp(1rem,5vw,3rem)] py-[clamp(0.5rem,2vw,1rem)] text-[clamp(1rem,3vw,2rem)] overflow-hidden [perspective:1000px]"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -37,7 +37,7 @@ export default function Buy() {
           <ImageWithFallback
             src={image}
             alt={heading.text}
-            className="mt-4 max-w-full"
+            className="mt-4 w-full h-auto"
           />
         )}
       </div>

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -22,7 +22,7 @@ export default function Connect() {
           <ImageWithFallback
             src={image}
             alt={heading.text}
-            className="mt-4 max-w-full"
+            className="mt-4 w-full h-auto"
           />
         )}
       </div>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -22,7 +22,7 @@ export default function Meet() {
           <ImageWithFallback
             src={image}
             alt={heading.text}
-            className="mt-4 max-w-full"
+            className="mt-4 w-full h-auto"
           />
         )}
       </div>

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -22,7 +22,7 @@ export default function Read() {
           <ImageWithFallback
             src={image}
             alt={heading.text}
-            className="mt-4 max-w-full"
+            className="mt-4 w-full h-auto"
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Reduce spacing between hero headers and subtitles while making subtitle text responsive
- Scale base font size to follow viewport width for better overall responsiveness
- Ensure hero button and images size fluidly with the window

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7c1728b408321a24e1a718c388d6b