### PR TITLE
Add issues carousel and admin controls

### DIFF
--- a/content/read.json
+++ b/content/read.json
@@ -15,5 +15,6 @@
       "className": "mt-2 text-center text-8xl font-sans"
     },
     "image": "/uploads/placeholder.png"
-  }
+  },
+  "issues": []
 }

--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -1,61 +1,6 @@
-import { useMemo } from "react";
 import ImageWithFallback from "./ImageWithFallback";
 
-export default function IssueCarousel({
-  issues: issuePosts,
-  loading,
-  error,
-  selectedId,
-  onSelect,
-}) {
-  if (loading) {
-    return (
-      <div className="w-full overflow-x-auto touch-pan-x">
-        <div className="flex space-x-4 p-4">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div
-              key={i}
-              className="flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden w-[150px] sm:w-[200px]"
-              style={{ borderColor: "var(--border)" }}
-            >
-              <div className="w-full aspect-square bg-[var(--muted)] animate-pulse" />
-              <div className="p-2 text-center">
-                <div className="h-4 bg-[var(--muted)] rounded w-3/4 mx-auto animate-pulse" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return <div>Error loading issues.</div>;
-  }
-
-  // Normalize cover images regardless of format
-  const issues = useMemo(() => {
-    return issuePosts.map((issue) => {
-      let coverImage = issue.cover_image;
-
-      if (Array.isArray(coverImage)) {
-        const first = coverImage[0];
-        coverImage = first?.url || first;
-      } else if (typeof coverImage === "object" && coverImage?.url) {
-        coverImage = coverImage.url;
-      }
-
-      return {
-        id: issue.id,
-        title: issue.title?.rendered || issue.title,
-        coverImage,
-        releaseDate: issue.release_date,
-        shortDescription: issue.short_description,
-        longDescription: issue.long_description,
-      };
-    });
-  }, [issuePosts]);
-
+export default function IssueCarousel({ issues = [], selectedId, onSelect }) {
   if (!issues.length) {
     return <div>No issues available.</div>;
   }
@@ -64,37 +9,38 @@ export default function IssueCarousel({
     <div className="w-full overflow-x-auto touch-pan-x">
       <div className="flex space-x-4 p-4">
         {issues.map((issue) => {
-          const handleClick = () => onSelect?.(issue.id);
+          const isSelected = selectedId === issue.order;
+          const handleClick = () => onSelect?.(isSelected ? null : issue.order);
           return (
             <div
-              key={issue.id}
+              key={issue.order}
               onClick={handleClick}
-              className={`flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden w-[150px] sm:w-[200px] transition-transform cursor-pointer hover:scale-105 ${
-                selectedId === issue.id ? "ring-2 ring-[var(--accent)]" : ""
-              }`}
+              className={[
+                "flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden w-[150px] sm:w-[200px] cursor-pointer",
+                isSelected ? "ring-2 ring-[var(--accent)]" : "",
+              ].join(" ")}
               style={{ borderColor: "var(--border)" }}
             >
               <div className="w-full aspect-square">
-                {issue.coverImage ? (
-                  <ImageWithFallback
-                    src={issue.coverImage}
-                    alt={issue.title}
-                    className="w-full h-full object-cover"
-                  />
-                ) : (
-                  <div className="w-full h-full bg-gray-200 animate-pulse" />
-                )}
+                <ImageWithFallback
+                  src={issue.thumbnail}
+                  alt={issue.title}
+                  className="w-full h-full object-cover"
+                />
               </div>
               <div className="p-2 text-center">
                 <p className="text-sm font-medium text-[var(--foreground)]">
-                  {issue.title || (
-                    <span className="inline-block h-4 w-20 rounded bg-gray-200 animate-pulse" />
-                  )}
+                  {issue.title}
                 </p>
               </div>
-              {!issue.coverImage && (
-                <div className="p-1 text-center text-xs text-red-500">
-                  Image unavailable
+              {isSelected && (
+                <div className="p-2 text-xs text-left space-y-1">
+                  <p className="font-semibold">{issue.subtitle}</p>
+                  <p>{issue.description}</p>
+                  <p>Writer: {issue.writer}</p>
+                  <p>Artist: {issue.artist}</p>
+                  <p>Colorist: {issue.colorist}</p>
+                  <p>Release: {issue.releaseDate}</p>
                 </div>
               )}
             </div>

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -113,6 +113,13 @@ export default function Admin() {
                     : renderInput(`${key}[${idx}]`, item, [...fieldPath, idx])}
                 </div>
               ))}
+              <button
+                type="button"
+                onClick={() => addArrayItem(fieldPath)}
+                className="px-2 py-1 text-sm border rounded"
+              >
+                Add
+              </button>
             </div>
           );
         }
@@ -125,6 +132,36 @@ export default function Admin() {
       }
       return renderInput(key, value, fieldPath);
     });
+
+  const getPlaceholder = (path, length) => {
+    const joined = path.join('.');
+    if (joined === 'issues') {
+      return {
+        order: length + 1,
+        releaseDate: 'date',
+        title: 'title',
+        subtitle: 'subtitle',
+        description: 'description',
+        writer: 'writer',
+        artist: 'artist',
+        colorist: 'colorist',
+        thumbnail: '/uploads/placeholder.png',
+      };
+    }
+    return '';
+  };
+
+  const addArrayItem = (path) => {
+    setFormData((prev) => {
+      const updated = structuredClone(prev);
+      let arr = updated;
+      for (let i = 0; i < path.length; i += 1) {
+        arr = arr[path[i]];
+      }
+      arr.push(getPlaceholder(path, arr.length));
+      return updated;
+    });
+  };
 
   const renderInput = (label, value, path) => {
     const name = path.join('.');
@@ -144,6 +181,7 @@ export default function Admin() {
       const isDate = !Number.isNaN(Date.parse(value)) && /\d{4}-\d{2}-\d{2}/.test(value);
       const isImageField =
         label.toLowerCase().includes('image') ||
+        label.toLowerCase().includes('thumbnail') ||
         /\.(png|jpe?g|gif|webp|svg)$/i.test(value);
       if (isImageField) {
         return (

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,13 +1,17 @@
+import { useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
 import ImageWithFallback from "../components/ImageWithFallback";
+import IssueCarousel from "../components/IssueCarousel";
 import content from "../../content/read.json";
 
 export default function Read() {
   const {
     panel,
     hero: { heading, subtitle, image },
+    issues = [],
   } = content;
+  const [selectedId, setSelectedId] = useState(null);
 
   return (
     <Panel id={panel.main.id}>
@@ -26,6 +30,13 @@ export default function Read() {
           />
         )}
       </div>
+      {issues.length > 0 && (
+        <IssueCarousel
+          issues={issues}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+        />
+      )}
     </Panel>
   );
 }


### PR DESCRIPTION
## Summary
- Allow admin to append comic issues with auto-filled placeholder fields and image uploads
- Add issues carousel on the Read page showing thumbnails that expand for more details
- Seed Read page content with an empty issues array

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7c23b07988321af5841623af15944