### PR TITLE
Add dark mode toggle with navy theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import Meet from "./pages/Meet";
 import Connect from "./pages/Connect";
 import Admin from "./pages/Admin";
 import Breadcrumbs from "./components/Breadcrumbs";
+import DarkModeToggle from "./components/DarkModeToggle";
 
 export default function App() {
   const location = useLocation();
@@ -20,8 +21,9 @@ export default function App() {
   }, [location.pathname]);
 
   return (
-    <div className="fixed inset-0 overflow-hidden p-3 bg-[#fdfaf5]">
+    <div className="fixed inset-0 overflow-hidden p-3 bg-[var(--background)] text-[var(--foreground)]">
       <Breadcrumbs className="absolute top-6 left-6 z-10" />
+      <DarkModeToggle className="absolute top-6 right-6 z-10" />
       <LayoutGroup>
         <AnimatePresence mode="wait">
           <Routes location={location} key={location.pathname}>

--- a/src/components/DarkModeToggle.jsx
+++ b/src/components/DarkModeToggle.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+export default function DarkModeToggle({ className = "" }) {
+  const [isDark, setIsDark] = useState(() =>
+    typeof window !== "undefined" && document.documentElement.classList.contains("dark")
+  );
+
+  useEffect(() => {
+    if (isDark) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, [isDark]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setIsDark(!isDark)}
+      className={`px-3 py-1 rounded border bg-[var(--background)] text-[var(--foreground)] border-[var(--border)] text-sm ${className}`}
+    >
+      {isDark ? "Light Mode" : "Dark Mode"}
+    </button>
+  );
+}

--- a/src/components/Panel.jsx
+++ b/src/components/Panel.jsx
@@ -4,7 +4,7 @@ export default function Panel({ id, children }) {
   return (
     <motion.div
       layoutId={`panel-${id}`}
-      className="w-full h-full border border-black rounded-lg overflow-hidden"
+      className="w-full h-full border border-[var(--border)] rounded-lg overflow-hidden"
     >
       <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6">
         <div className="flex-1 flex items-center justify-center">{children}</div>

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -18,7 +18,7 @@ export default function PanelCard({
       initial={initial}
       animate={animate}
         transition={transition}
-        className={`relative w-full h-full cursor-pointer border border-black rounded-lg overflow-hidden group bg-transparent flex items-center justify-center ${className}`}
+        className={`relative w-full h-full cursor-pointer border border-[var(--border)] rounded-lg overflow-hidden group bg-transparent flex items-center justify-center ${className}`}
     >
       {imageSrc && (
         <ImageWithFallback
@@ -30,7 +30,7 @@ export default function PanelCard({
       {label && (
         <motion.span
           layoutId={label}
-          className="pointer-events-none text-black font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
+          className="pointer-events-none text-[var(--foreground)] font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
         >
           {label}
         </motion.span>

--- a/src/index.css
+++ b/src/index.css
@@ -22,11 +22,11 @@ body,
 }
 
 .dark {
-  --background: #0d1117;
-  --foreground: #f1f5f9;
+  --background: #000a1f;
+  --foreground: #ffffff;
   --accent: #3b82f6;
   --muted: #64748b;
-  --border: #1e293b;
+  --border: #334155;
 }
 
 @layer base {

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -46,19 +46,19 @@ export default function Admin() {
 
   if (!authorized) {
     return (
-      <div className="w-full h-full border border-black rounded-lg overflow-hidden">
+      <div className="w-full h-full border border-[var(--border)] rounded-lg overflow-hidden">
         <div className="h-full flex items-center justify-center p-6">
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <input
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="border px-3 py-2 rounded"
+              className="border border-[var(--border)] px-3 py-2 rounded"
               placeholder="Password"
             />
             <button
               type="submit"
-              className="bg-black text-white px-4 py-2 rounded"
+              className="bg-[var(--foreground)] text-[var(--background)] px-4 py-2 rounded"
             >
               Enter
             </button>
@@ -157,7 +157,7 @@ export default function Admin() {
           );
         }
         return (
-          <fieldset key={fieldPath.join('.')} className="border p-2">
+          <fieldset key={fieldPath.join('.')} className="border border-[var(--border)] p-2">
             <legend className="font-semibold">{key}</legend>
             {renderFields(value, fieldPath)}
           </fieldset>
@@ -202,7 +202,7 @@ export default function Admin() {
                 e.preventDefault();
                 handleImageUpload(e.dataTransfer.files[0], path);
               }}
-              className="border border-dashed rounded p-4 text-center"
+              className="border border-[var(--border)] border-dashed rounded p-4 text-center"
             >
               <input
                 id={`${name}-file`}
@@ -226,7 +226,7 @@ export default function Admin() {
               <select
                 value={value}
                 onChange={handleChange}
-                className="border px-2 py-1 rounded"
+                className="border border-[var(--border)] px-2 py-1 rounded"
               >
                 {SIZE_OPTIONS.map((opt) => (
                   <option key={opt} value={opt}>
@@ -254,7 +254,7 @@ export default function Admin() {
                 type="date"
                 value={value.slice(0, 10)}
                 onChange={handleChange}
-                className="border px-2 py-1 rounded"
+                className="border border-[var(--border)] px-2 py-1 rounded"
               />
               <button
                 type="button"
@@ -275,7 +275,7 @@ export default function Admin() {
               <textarea
                 value={value}
                 onChange={handleChange}
-                className="border px-2 py-1 rounded flex-1"
+                className="border border-[var(--border)] px-2 py-1 rounded flex-1"
               />
               <button
                 type="button"
@@ -296,7 +296,7 @@ export default function Admin() {
               type="text"
               value={value}
               onChange={handleChange}
-              className="border px-2 py-1 rounded"
+              className="border border-[var(--border)] px-2 py-1 rounded"
             />
             <button
               type="button"
@@ -318,7 +318,7 @@ export default function Admin() {
               type="number"
               value={value}
               onChange={handleChange}
-              className="border px-2 py-1 rounded"
+              className="border border-[var(--border)] px-2 py-1 rounded"
             />
             <button
               type="button"
@@ -368,7 +368,7 @@ export default function Admin() {
 
   if (selectedPage && formData) {
     return (
-      <div className="w-full h-full border border-black rounded-lg overflow-hidden">
+      <div className="w-full h-full border border-[var(--border)] rounded-lg overflow-hidden">
         <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6 gap-4">
           <h1 className="text-2xl font-bold">Edit {selectedPage.name}</h1>
           {error && <div className="text-red-500">{error}</div>}
@@ -378,7 +378,7 @@ export default function Admin() {
               <button
                 type="submit"
                 disabled={saving}
-                className="bg-black text-white px-4 py-2 rounded"
+                className="bg-[var(--foreground)] text-[var(--background)] px-4 py-2 rounded"
               >
                 {saving ? 'Saving...' : 'Save'}
               </button>
@@ -397,7 +397,7 @@ export default function Admin() {
   }
 
   return (
-    <div className="w-full h-full border border-black rounded-lg overflow-hidden">
+    <div className="w-full h-full border border-[var(--border)] rounded-lg overflow-hidden">
       <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6">
         <h1 className="text-2xl font-bold mb-6">Admin Dashboard</h1>
         {error && <div className="text-red-500 mb-4">{error}</div>}
@@ -405,7 +405,7 @@ export default function Admin() {
           {PAGES.map((page) => (
             <li
               key={page.id}
-              className="border p-4 rounded cursor-pointer hover:bg-gray-50"
+              className="border border-[var(--border)] p-4 rounded cursor-pointer hover:bg-[var(--muted)]/20"
               onClick={() => loadPage(page)}
             >
               {page.name}

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -26,7 +26,7 @@ export default function Buy() {
         {button && (
           <a
             href={button.url}
-            className="mt-4 group relative inline-flex items-center justify-center rounded bg-black px-6 py-3 text-white overflow-hidden"
+            className="mt-4 group relative inline-flex items-center justify-center rounded bg-[var(--foreground)] px-6 py-3 text-[var(--background)] overflow-hidden"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Summary
- add toggle component to switch between light and dark themes
- set dark mode to use deep navy background with white text
- update panels, cards and buttons to respect theme variables

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7c50c4910832194224fa3915945ed