### PR TITLE
Add issue detail subpages and adjust read layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import { updatePreviousPathname } from "./utils/navigation";
 
 import PanelGrid from "./components/PanelGrid";
 import Read from "./pages/Read";
+import IssueDetail from "./pages/IssueDetail";
 import Buy from "./pages/Buy";
 import Meet from "./pages/Meet";
 import Connect from "./pages/Connect";
@@ -27,6 +28,7 @@ export default function App() {
           <Routes location={location} key={location.pathname}>
             <Route path="/" element={<PanelGrid />} />
             <Route path="/read" element={<Read />} />
+            <Route path="/read/:issueId" element={<IssueDetail />} />
             <Route path="/buy" element={<Buy />} />
             <Route path="/meet" element={<Meet />} />
             <Route path="/connect" element={<Connect />} />

--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -1,6 +1,8 @@
+import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
 import ImageWithFallback from "./ImageWithFallback";
 
-export default function IssueCarousel({ issues = [], selectedId, onSelect }) {
+export default function IssueCarousel({ issues = [] }) {
   if (!issues.length) {
     return <div>No issues available.</div>;
   }
@@ -8,17 +10,11 @@ export default function IssueCarousel({ issues = [], selectedId, onSelect }) {
   return (
     <div className="w-full overflow-x-auto touch-pan-x">
       <div className="flex space-x-4 p-4">
-        {issues.map((issue) => {
-          const isSelected = selectedId === issue.order;
-          const handleClick = () => onSelect?.(isSelected ? null : issue.order);
-          return (
-            <div
-              key={issue.order}
-              onClick={handleClick}
-              className={[
-                "flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden w-[150px] sm:w-[200px] cursor-pointer",
-                isSelected ? "ring-2 ring-[var(--accent)]" : "",
-              ].join(" ")}
+        {issues.map((issue) => (
+          <Link key={issue.order} to={`/read/${issue.order}`} className="block">
+            <motion.div
+              layoutId={`panel-issue-${issue.order}`}
+              className="flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden w-[150px] sm:w-[200px] cursor-pointer"
               style={{ borderColor: "var(--border)" }}
             >
               <div className="w-full aspect-square">
@@ -33,20 +29,11 @@ export default function IssueCarousel({ issues = [], selectedId, onSelect }) {
                   {issue.title}
                 </p>
               </div>
-              {isSelected && (
-                <div className="p-2 text-xs text-left space-y-1">
-                  <p className="font-semibold">{issue.subtitle}</p>
-                  <p>{issue.description}</p>
-                  <p>Writer: {issue.writer}</p>
-                  <p>Artist: {issue.artist}</p>
-                  <p>Colorist: {issue.colorist}</p>
-                  <p>Release: {issue.releaseDate}</p>
-                </div>
-              )}
-            </div>
-          );
-        })}
+            </motion.div>
+          </Link>
+        ))}
       </div>
     </div>
   );
 }
+

--- a/src/components/Panel.jsx
+++ b/src/components/Panel.jsx
@@ -1,13 +1,17 @@
 import { motion } from "framer-motion";
 
-export default function Panel({ id, children }) {
+export default function Panel({ id, children, centerChildren = true }) {
   return (
     <motion.div
       layoutId={`panel-${id}`}
       className="w-full h-full border border-black rounded-lg overflow-hidden"
     >
       <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6">
-        <div className="flex-1 flex items-center justify-center">{children}</div>
+        <div
+          className={["flex-1", centerChildren ? "flex items-center justify-center" : ""].join(" ")}
+        >
+          {children}
+        </div>
       </div>
     </motion.div>
   );

--- a/src/pages/IssueDetail.jsx
+++ b/src/pages/IssueDetail.jsx
@@ -1,0 +1,34 @@
+import { useParams } from "react-router-dom";
+import Panel from "../components/Panel";
+import ImageWithFallback from "../components/ImageWithFallback";
+import IssueInfoPanel from "../components/IssueInfoPanel";
+import content from "../../content/read.json";
+
+export default function IssueDetail() {
+  const { issueId } = useParams();
+  const issue = content.issues?.find((i) => String(i.order) === issueId);
+
+  if (!issue) {
+    return (
+      <Panel id={`issue-${issueId}`}>
+        <div className="text-center">Issue not found.</div>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel id={`issue-${issueId}`} centerChildren={false}>
+      <div className="flex flex-col items-center">
+        {issue.thumbnail && (
+          <ImageWithFallback
+            src={issue.thumbnail}
+            alt={issue.title}
+            className="w-full h-auto"
+          />
+        )}
+        <IssueInfoPanel issue={issue} />
+      </div>
+    </Panel>
+  );
+}
+

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
 import ImageWithFallback from "../components/ImageWithFallback";
@@ -11,10 +10,9 @@ export default function Read() {
     hero: { heading, subtitle, image },
     issues = [],
   } = content;
-  const [selectedId, setSelectedId] = useState(null);
 
   return (
-    <Panel id={panel.main.id}>
+    <Panel id={panel.main.id} centerChildren={false}>
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={heading.layoutId}
@@ -35,13 +33,7 @@ export default function Read() {
           />
         )}
       </div>
-      {issues.length > 0 && (
-        <IssueCarousel
-          issues={issues}
-          selectedId={selectedId}
-          onSelect={setSelectedId}
-        />
-      )}
+      {issues.length > 0 && <IssueCarousel issues={issues} />}
     </Panel>
   );
 }


### PR DESCRIPTION
## Summary
- Add optional centering to Panel component
- Center Read page header and place issue tiles below it
- Link issue thumbnails to dedicated detail panels
- Introduce IssueDetail page and route for issue info

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7c5cfa37c8321b30450e8436a1d1f