### PR TITLE
feat: add configurable panel images

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -24,7 +24,7 @@ export default function PanelCard({
         <ImageWithFallback
           src={imageSrc}
           alt={label}
-          className="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-300 group-hover:opacity-[0.35] group-hover:grayscale"
+          className="absolute inset-0 w-full h-full object-cover filter grayscale contrast-75 transition duration-300 group-hover:grayscale-0 group-hover:contrast-100 group-hover:saturate-[0.75]"
         />
       )}
       {label && (

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,26 +1,30 @@
 import PanelCard from "./PanelCard";
 import { getPreviousPathname } from "../utils/navigation";
+import read from "../../content/read.json";
+import buy from "../../content/buy.json";
+import meet from "../../content/meet.json";
+import connect from "../../content/connect.json";
 
 const panels = [
   {
     label: "READ",
     to: "/read",
-    image: "https://source.unsplash.com/random/800x1200?sig=1",
+    image: read.panel?.image,
   },
   {
     label: "BUY",
     to: "/buy",
-    image: "https://source.unsplash.com/random/800x1200?sig=2",
+    image: buy.panel?.image,
   },
   {
     label: "MEET",
     to: "/meet",
-    image: "https://source.unsplash.com/random/800x1200?sig=3",
+    image: meet.panel?.image,
   },
   {
     label: "CONNECT",
     to: "/connect",
-    image: "https://source.unsplash.com/random/800x1200?sig=4",
+    image: connect.panel?.image,
   },
 ];
 

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -205,6 +205,7 @@ export default function Admin() {
 
   const renderInput = (label, value, path) => {
     const name = path.join('.');
+    const displayLabel = name === 'panel.image' ? 'Panel Image' : label;
     const handleChange = (e) => {
       let val;
       if (typeof value === 'number') {
@@ -226,7 +227,7 @@ export default function Admin() {
       if (isImageField) {
         return (
           <div key={name} className="flex flex-col gap-1">
-            <label className="font-medium">{label}</label>
+            <label className="font-medium">{displayLabel}</label>
             {value && (
               <img
                 src={value}
@@ -259,7 +260,7 @@ export default function Admin() {
       if (path[path.length - 1] === 'size') {
         return (
           <div key={name} className="flex flex-col gap-1">
-            <label className="font-medium">{label}</label>
+            <label className="font-medium">{displayLabel}</label>
             <div className="flex items-center gap-2">
               <select
                 value={value}
@@ -286,7 +287,7 @@ export default function Admin() {
       if (isDate) {
         return (
           <div key={name} className="flex flex-col gap-1">
-            <label className="font-medium">{label}</label>
+            <label className="font-medium">{displayLabel}</label>
             <div className="flex items-center gap-2">
               <input
                 type="date"
@@ -308,7 +309,7 @@ export default function Admin() {
       if (value.length > 60 || value.includes('\n')) {
         return (
           <div key={name} className="flex flex-col gap-1">
-            <label className="font-medium">{label}</label>
+            <label className="font-medium">{displayLabel}</label>
             <div className="flex items-center gap-2">
               <textarea
                 value={value}
@@ -328,7 +329,7 @@ export default function Admin() {
       }
       return (
         <div key={name} className="flex flex-col gap-1">
-          <label className="font-medium">{label}</label>
+          <label className="font-medium">{displayLabel}</label>
           <div className="flex items-center gap-2">
             <input
               type="text"
@@ -350,7 +351,7 @@ export default function Admin() {
     if (typeof value === 'number') {
       return (
         <div key={name} className="flex flex-col gap-1">
-          <label className="font-medium">{label}</label>
+          <label className="font-medium">{displayLabel}</label>
           <div className="flex items-center gap-2">
             <input
               type="number"
@@ -373,7 +374,7 @@ export default function Admin() {
       return (
         <div key={name} className="flex items-center gap-2">
           <input type="checkbox" checked={value} onChange={handleChange} />
-          <label className="font-medium flex-1">{label}</label>
+          <label className="font-medium flex-1">{displayLabel}</label>
           <button
             type="button"
             onClick={() => resetField(path)}


### PR DESCRIPTION
## Summary
- use panel-specific images from content files on the home page
- show panel images in grayscale with low contrast and add color on hover
- label admin panel's image field as "Panel Image"

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9ee4d08688321aceec17a81ad0a69