### PR TITLE
Add bottom margin to subpage headers

### DIFF
--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -17,7 +17,7 @@ export default function IssueInfoPanel({ issue }) {
       style={{ borderColor: "var(--border)" }}
     >
       <div className="text-center">
-        <h2 className="text-2xl font-bold">{title}</h2>
+        <h2 className="text-2xl font-bold mb-2">{title}</h2>
         {issue.subtitle && (
           <h3 className="text-lg text-gray-500">{issue.subtitle}</h3>
         )}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -409,7 +409,7 @@ export default function Admin() {
     return (
       <div className="w-full h-full border border-black rounded-lg overflow-hidden">
         <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6 gap-4">
-          <h1 className="text-2xl font-bold">Edit {selectedPage.name}</h1>
+          <h1 className="text-2xl font-bold mb-2">Edit {selectedPage.name}</h1>
           {error && <div className="text-red-500">{error}</div>}
           <form onSubmit={handleSave} className="flex flex-col gap-4">
             {renderFields(formData)}
@@ -438,7 +438,7 @@ export default function Admin() {
   return (
     <div className="w-full h-full border border-black rounded-lg overflow-hidden">
       <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6">
-        <h1 className="text-2xl font-bold mb-6">Admin Dashboard</h1>
+        <h1 className="text-2xl font-bold mb-2">Admin Dashboard</h1>
         {error && <div className="text-red-500 mb-4">{error}</div>}
         <ul className="space-y-4">
           {PAGES.map((page) => (

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -14,7 +14,7 @@ export default function Buy() {
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={heading.layoutId}
-          className={`${heading.className} ${heading.size}`}
+          className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}
         </motion.h1>

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -14,7 +14,7 @@ export default function Connect() {
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={heading.layoutId}
-          className={`${heading.className} ${heading.size}`}
+          className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}
         </motion.h1>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -14,7 +14,7 @@ export default function Meet() {
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={heading.layoutId}
-          className={`${heading.className} ${heading.size}`}
+          className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}
         </motion.h1>

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -16,7 +16,7 @@ export default function Read() {
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={heading.layoutId}
-          className={`${heading.className} ${heading.size}`}
+          className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}
         </motion.h1>


### PR DESCRIPTION
## Summary
- add mb-2 spacing to subpage page headers for consistent layout
- update issue detail title and admin headers with mb-2

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f4cb0ca483218eb15dcdb9d3872f