### PR TITLE
Add placeholder panel images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ pnpm-debug.log*
 # uploads
 public/uploads/*
 !public/uploads/.gitkeep
+!public/uploads/placeholder.png
 
 #page content: local until launch on site
 #/content
+

--- a/content/buy.json
+++ b/content/buy.json
@@ -2,7 +2,8 @@
   "panel": {
     "main": {
       "id": "BUY"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   },
   "hero": {
     "heading": {

--- a/content/connect.json
+++ b/content/connect.json
@@ -2,20 +2,21 @@
   "panel": {
     "main": {
       "id": "CONNECT"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   },
-    "hero": {
-      "heading": {
-        "layoutId": "CONNECT",
-        "text": "CONNECT",
+  "hero": {
+    "heading": {
+      "layoutId": "CONNECT",
+      "text": "CONNECT",
       "className": "text-black font-bold uppercase",
       "size": "text-[clamp(3rem,8vw,10rem)]"
-      },
-      "subtitle": {
-        "text": "",
+    },
+    "subtitle": {
+      "text": "",
       "className": "mt-2 text-center font-sans",
       "size": "text-8xl"
-      },
-      "image": "/uploads/placeholder.png"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   }
+}

--- a/content/meet.json
+++ b/content/meet.json
@@ -2,20 +2,21 @@
   "panel": {
     "main": {
       "id": "MEET"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   },
-    "hero": {
-      "heading": {
-        "layoutId": "MEET",
-        "text": "MEET",
+  "hero": {
+    "heading": {
+      "layoutId": "MEET",
+      "text": "MEET",
       "className": "text-black font-bold uppercase",
       "size": "text-[clamp(3rem,8vw,10rem)]"
-      },
-      "subtitle": {
-        "text": "",
+    },
+    "subtitle": {
+      "text": "",
       "className": "mt-2 text-center font-sans",
       "size": "text-8xl"
-      },
-      "image": "/uploads/placeholder.png"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   }
+}

--- a/content/read.json
+++ b/content/read.json
@@ -2,7 +2,8 @@
   "panel": {
     "main": {
       "id": "READ"
-    }
+    },
+    "image": "/uploads/placeholder.png"
   },
   "hero": {
     "heading": {

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -4,27 +4,29 @@ import read from "../../content/read.json";
 import buy from "../../content/buy.json";
 import meet from "../../content/meet.json";
 import connect from "../../content/connect.json";
+ 
+const placeholderImage = "/uploads/placeholder.png";
 
 const panels = [
   {
     label: "READ",
     to: "/read",
-    image: read.panel?.image,
+    image: read.panel?.image || placeholderImage,
   },
   {
     label: "BUY",
     to: "/buy",
-    image: buy.panel?.image,
+    image: buy.panel?.image || placeholderImage,
   },
   {
     label: "MEET",
     to: "/meet",
-    image: meet.panel?.image,
+    image: meet.panel?.image || placeholderImage,
   },
   {
     label: "CONNECT",
     to: "/connect",
-    image: connect.panel?.image,
+    image: connect.panel?.image || placeholderImage,
   },
 ];
 


### PR DESCRIPTION
## Summary
- add placeholder image URLs to all panel content pages
- ensure PanelGrid falls back to placeholder images
- allow placeholder asset to be supplied manually

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f58ffa3c832182cf027ef38671d4