### PR TITLE
Remove hero images from subpages and admin

### DIFF
--- a/content/buy.json
+++ b/content/buy.json
@@ -21,7 +21,6 @@
       "url": "https://www.kickstarter.com/projects/jmintonjohnson/renowned-2-supernatural-detective-series/",
       "defaultText": "Issue #2",
       "hoverText": "Follow Now!"
-    },
-    "image": "/uploads/placeholder.png"
+    }
   }
 }

--- a/content/connect.json
+++ b/content/connect.json
@@ -16,7 +16,6 @@
       "text": "",
       "className": "mt-2 text-center font-sans",
       "size": "text-8xl"
-    },
-    "image": "/uploads/placeholder.png"
+    }
   }
 }

--- a/content/meet.json
+++ b/content/meet.json
@@ -16,7 +16,6 @@
       "text": "",
       "className": "mt-2 text-center font-sans",
       "size": "text-8xl"
-    },
-    "image": "/uploads/placeholder.png"
+    }
   }
 }

--- a/content/read.json
+++ b/content/read.json
@@ -14,8 +14,7 @@
     "subtitle": {
       "text": "",
       "className": "mt-2 text-center text-8xl font-sans"
-    },
-    "image": "/uploads/1757015105407-444807703.jpg"
+    }
   },
   "issues": [
     {

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -141,6 +141,9 @@ export default function Admin() {
   const renderFields = (data, path = []) =>
     Object.entries(data).map(([key, value]) => {
       const fieldPath = [...path, key];
+      if (path[0] === "hero" && path.length === 1 && key === "image") {
+        return null;
+      }
       if (typeof value === "object" && value !== null) {
         if (Array.isArray(value)) {
           return (

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,12 +1,11 @@
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
-import ImageWithFallback from "../components/ImageWithFallback";
 import content from "../../content/buy.json";
 
 export default function Buy() {
   const {
     panel,
-    hero: { heading, subtitle, image, button },
+    hero: { heading, subtitle, button },
   } = content;
 
   return (
@@ -37,13 +36,6 @@ export default function Buy() {
               {button.hoverText}
             </span>
           </a>
-        )}
-        {image && (
-          <ImageWithFallback
-            src={image}
-            alt={heading.text}
-            className="mt-4 w-full h-auto"
-          />
         )}
       </div>
     </Panel>

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -1,12 +1,11 @@
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
-import ImageWithFallback from "../components/ImageWithFallback";
 import content from "../../content/connect.json";
 
 export default function Connect() {
   const {
     panel,
-    hero: { heading, subtitle, image },
+    hero: { heading, subtitle },
   } = content;
 
   return (
@@ -22,13 +21,6 @@ export default function Connect() {
           <p className={`${subtitle.className} ${subtitle.size}`}>
             {subtitle.text}
           </p>
-        )}
-        {image && (
-          <ImageWithFallback
-            src={image}
-            alt={heading.text}
-            className="mt-4 w-full h-auto"
-          />
         )}
       </div>
     </Panel>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -1,12 +1,11 @@
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
-import ImageWithFallback from "../components/ImageWithFallback";
 import content from "../../content/meet.json";
 
 export default function Meet() {
   const {
     panel,
-    hero: { heading, subtitle, image },
+    hero: { heading, subtitle },
   } = content;
 
   return (
@@ -22,13 +21,6 @@ export default function Meet() {
           <p className={`${subtitle.className} ${subtitle.size}`}>
             {subtitle.text}
           </p>
-        )}
-        {image && (
-          <ImageWithFallback
-            src={image}
-            alt={heading.text}
-            className="mt-4 w-full h-auto"
-          />
         )}
       </div>
     </Panel>

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,13 +1,12 @@
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
-import ImageWithFallback from "../components/ImageWithFallback";
 import IssueCarousel from "../components/IssueCarousel";
 import content from "../../content/read.json";
 
 export default function Read() {
   const {
     panel,
-    hero: { heading, subtitle, image },
+    hero: { heading, subtitle },
     issues = [],
   } = content;
 
@@ -24,13 +23,6 @@ export default function Read() {
           <p className={`${subtitle.className} ${subtitle.size}`}>
             {subtitle.text}
           </p>
-        )}
-        {image && (
-          <ImageWithFallback
-            src={image}
-            alt={heading.text}
-            className="mt-4 w-full h-auto"
-          />
         )}
       </div>
       {issues.length > 0 && <IssueCarousel issues={issues} />}


### PR DESCRIPTION
## Summary
- drop `hero.image` data from all subpage content files
- remove hero image rendering on Buy, Connect, Meet, and Read pages
- hide the hero image field in the admin dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb0da68bcc83219b4e70bfa643f886