### PR TITLE
Refine home page panel return animations

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -10,6 +10,8 @@ export default function PanelCard({
   initial,
   animate,
   transition,
+  isTransforming = false,
+  fadeDelay = 0,
 }) {
   const content = (
     <motion.div
@@ -17,15 +19,22 @@ export default function PanelCard({
       whileHover={{ scale: 1.02 }}
       initial={initial}
       animate={animate}
-        transition={transition}
-        className={`relative w-full h-full cursor-pointer border border-black rounded-lg overflow-hidden group bg-transparent flex items-center justify-center ${className}`}
+      transition={transition}
+      className={`relative w-full h-full cursor-pointer border border-black rounded-lg overflow-hidden group bg-transparent flex items-center justify-center ${className}`}
     >
       {imageSrc && (
-        <ImageWithFallback
-          src={imageSrc}
-          alt={label}
-          className="absolute inset-0 w-full h-full object-cover z-0 filter grayscale contrast-50 blur-sm transition duration-300 group-hover:grayscale-0 group-hover:contrast-100 group-hover:saturate-[0.75] group-hover:blur-0"
-        />
+        <motion.div
+          initial={isTransforming ? { opacity: 0 } : undefined}
+          animate={isTransforming ? { opacity: 1 } : undefined}
+          transition={isTransforming ? { delay: fadeDelay, duration: 0.4 } : undefined}
+          className="absolute inset-0 w-full h-full"
+        >
+          <ImageWithFallback
+            src={imageSrc}
+            alt={label}
+            className="absolute inset-0 w-full h-full object-cover z-0 filter grayscale contrast-50 blur-sm transition duration-300 group-hover:grayscale-0 group-hover:contrast-100 group-hover:saturate-[0.75] group-hover:blur-0"
+          />
+        </motion.div>
       )}
       {label && (
         <motion.span

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -30,6 +30,8 @@ const panels = [
   },
 ];
 
+const TRANSFORM_DURATION = 0.4;
+
 export default function PanelGrid() {
   const prevPath = getPreviousPathname();
   const fromPanel = prevPath && prevPath !== "/" ? prevPath.slice(1).toUpperCase() : null;
@@ -38,12 +40,13 @@ export default function PanelGrid() {
     <div className="h-full flex flex-col px-6 pt-10 pb-6">
       <div className="flex-1 grid w-full grid-cols-2 grid-rows-2 gap-4">
         {panels.map((panel) => {
+          const isTransforming = fromPanel && panel.label === fromPanel;
           const fadeProps =
             fromPanel && panel.label !== fromPanel
               ? {
                   initial: { opacity: 0 },
                   animate: { opacity: 1 },
-                  transition: { duration: 0.4 },
+                  transition: { delay: TRANSFORM_DURATION, duration: 0.4 },
                 }
               : {};
 
@@ -54,6 +57,8 @@ export default function PanelGrid() {
               imageSrc={panel.image}
               label={panel.label}
               to={panel.to}
+              isTransforming={isTransforming}
+              fadeDelay={TRANSFORM_DURATION}
               {...fadeProps}
             />
           );


### PR DESCRIPTION
## Summary
- Fade returned panel image in after layout transform
- Delay non-transforming panels until transform completes

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb111ff4c08321acf23b4b56d83a74