### PR TITLE
Fix panel border transform returning home

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,7 @@ export default function App() {
     <div className="fixed inset-0 overflow-hidden p-3 bg-[#fdfaf5]">
       <Breadcrumbs className="absolute top-6 left-6 z-10" />
       <LayoutGroup>
-        <AnimatePresence mode="wait">
+        <AnimatePresence>
           <Routes location={location} key={location.pathname}>
             <Route path="/" element={<PanelGrid />} />
             <Route path="/read" element={<Read />} />


### PR DESCRIPTION
## Summary
- Ensure shared layout animations persist across pages by removing `mode="wait"` from AnimatePresence

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bce6a748a883218d4b258f30ce2a0f