### PR TITLE
Add subtitle sizing for Read page

### DIFF
--- a/content/read.json
+++ b/content/read.json
@@ -9,11 +9,13 @@
     "heading": {
       "layoutId": "READ",
       "text": "READ",
-      "className": "text-black font-bold uppercase text-[clamp(3rem,8vw,10rem)]"
+      "className": "text-black font-bold uppercase",
+      "size": "text-[clamp(3rem,8vw,10rem)]"
     },
     "subtitle": {
       "text": "",
-      "className": "mt-2 text-center text-8xl font-sans"
+      "className": "mt-2 text-center font-sans",
+      "size": "text-8xl"
     }
   },
   "issues": [


### PR DESCRIPTION
## Summary
- expose hero heading and subtitle size options on the Read page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bce6b12eac832196568d5305062b95