### PR TITLE
feat: add hero image layout for issue pages

### DIFF
--- a/content/read.json
+++ b/content/read.json
@@ -26,6 +26,7 @@
       "writer": "Jordan Johnson",
       "artist": "Azrael Aguiar",
       "colorist": "Maja Opacic",
+      "heroImage": "/uploads/placeholder.png",
       "thumbnail": "/uploads/placeholder.png"
     }
   ]

--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -13,24 +13,23 @@ export default function IssueInfoPanel({ issue }) {
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 20 }}
-      className="flex flex-col items-center gap-4 p-4 mt-4 border rounded bg-[var(--background)]"
-      style={{ borderColor: "var(--border)" }}
+      className="flex flex-col gap-4 mt-6 w-full"
     >
       <div className="text-center">
-        <h2 className="text-2xl font-bold mb-2">{title}</h2>
-        {issue.subtitle && (
-          <h3 className="text-lg text-gray-500">{issue.subtitle}</h3>
+        <h1 className="text-3xl font-bold">{title}</h1>
+        {(issue.writer || issue.artist || issue.colorist) && (
+          <div className="mt-2 text-sm text-gray-500">
+            {issue.writer && <p>Writer: {issue.writer}</p>}
+            {issue.artist && <p>Artist: {issue.artist}</p>}
+            {issue.colorist && <p>Colorist: {issue.colorist}</p>}
+          </div>
         )}
       </div>
-      {issue.long_description && (
-        <p className="max-w-xl text-center">{issue.long_description}</p>
+      {issue.subtitle && (
+        <h2 className="text-gray-500 text-left">{issue.subtitle}</h2>
       )}
-      {(issue.writer || issue.artist || issue.colorist) && (
-        <div className="text-sm text-gray-500 text-center">
-          {issue.writer && <p>Writer: {issue.writer}</p>}
-          {issue.artist && <p>Artist: {issue.artist}</p>}
-          {issue.colorist && <p>Colorist: {issue.colorist}</p>}
-        </div>
+      {issue.description && (
+        <p className="text-left text-black">{issue.description}</p>
       )}
     </motion.div>
   );

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -188,6 +188,7 @@ export default function Admin() {
         writer: 'writer',
         artist: 'artist',
         colorist: 'colorist',
+        heroImage: '/uploads/placeholder.png',
         thumbnail: '/uploads/placeholder.png',
       };
     }

--- a/src/pages/IssueDetail.jsx
+++ b/src/pages/IssueDetail.jsx
@@ -18,13 +18,21 @@ export default function IssueDetail() {
 
   return (
     <Panel id={`issue-${issueId}`} centerChildren={false}>
-      <div className="flex flex-col items-center">
-        {issue.thumbnail && (
-          <ImageWithFallback
-            src={issue.thumbnail}
-            alt={issue.title}
-            className="w-full h-auto"
-          />
+      <div className="flex flex-col">
+        {issue.heroImage && (
+          <div className="w-full h-[50vh] overflow-hidden">
+            <ImageWithFallback
+              src={issue.heroImage}
+              alt={issue.title}
+              className="w-full h-full object-cover"
+              style={{
+                WebkitMaskImage:
+                  "linear-gradient(to bottom, black 50%, transparent 100%)",
+                maskImage:
+                  "linear-gradient(to bottom, black 50%, transparent 100%)",
+              }}
+            />
+          </div>
         )}
         <IssueInfoPanel issue={issue} />
       </div>


### PR DESCRIPTION
## Summary
- support dedicated hero images for issues in content and admin
- restyle issue detail pages with fading hero image and new text layout
- show centered title/credits with left-aligned subtitle and description

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bce7b2b3f08321937ba8760aa09b10