### PR TITLE
feat: smooth route transitions with overlayed pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,10 +21,10 @@ export default function App() {
   }, [location.pathname]);
 
   return (
-    <div className="fixed inset-0 overflow-hidden p-3 bg-[#fdfaf5]">
+    <div className="relative fixed inset-0 overflow-hidden p-3 bg-[#fdfaf5]">
       <Breadcrumbs className="absolute top-6 left-6 z-10" />
       <LayoutGroup>
-        <AnimatePresence>
+        <AnimatePresence mode="wait" initial={false}>
           <Routes location={location} key={location.pathname}>
             <Route path="/" element={<PanelGrid />} />
             <Route path="/read" element={<Read />} />

--- a/src/components/Panel.jsx
+++ b/src/components/Panel.jsx
@@ -4,7 +4,7 @@ export default function Panel({ id, children, centerChildren = true }) {
   return (
     <motion.div
       layoutId={`panel-${id}`}
-      className="w-full h-full border border-black rounded-lg overflow-hidden"
+      className="absolute inset-0 w-full h-full border border-black rounded-lg overflow-hidden"
     >
       <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6">
         <div

--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -37,7 +37,7 @@ export default function PanelGrid() {
   const fromPanel = prevPath && prevPath !== "/" ? prevPath.slice(1).toUpperCase() : null;
 
   return (
-    <div className="h-full flex flex-col px-6 pt-10 pb-6">
+    <div className="absolute inset-0 h-full flex flex-col px-6 pt-10 pb-6">
       <div className="flex-1 grid w-full grid-cols-2 grid-rows-2 gap-4">
         {panels.map((panel) => {
           const isTransforming = fromPanel && panel.label === fromPanel;

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -46,7 +46,7 @@ export default function Admin() {
 
   if (!authorized) {
     return (
-      <div className="w-full h-full border border-black rounded-lg overflow-hidden">
+      <div className="absolute inset-0 w-full h-full border border-black rounded-lg overflow-hidden">
         <div className="h-full flex items-center justify-center p-6">
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <input
@@ -411,7 +411,7 @@ export default function Admin() {
 
   if (selectedPage && formData) {
     return (
-      <div className="w-full h-full border border-black rounded-lg overflow-hidden">
+      <div className="absolute inset-0 w-full h-full border border-black rounded-lg overflow-hidden">
         <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6 gap-4">
           <h1 className="text-2xl font-bold mb-2">Edit {selectedPage.name}</h1>
           {error && <div className="text-red-500">{error}</div>}
@@ -440,7 +440,7 @@ export default function Admin() {
   }
 
   return (
-    <div className="w-full h-full border border-black rounded-lg overflow-hidden">
+    <div className="absolute inset-0 w-full h-full border border-black rounded-lg overflow-hidden">
       <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6">
         <h1 className="text-2xl font-bold mb-2">Admin Dashboard</h1>
         {error && <div className="text-red-500 mb-4">{error}</div>}


### PR DESCRIPTION
## Summary
- wait for previous route exit with AnimatePresence
- overlay pages during transitions via absolute positioning

## Testing
- `npm run lint`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68c5c3e5b5248321868f1ce7ef8c5afe