### PR TITLE
Log upload and file operation errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ app.get('/api/pages/:page', async (req, res) => {
     const data = await fs.readFile(file, 'utf8');
     res.json(JSON.parse(data));
   } catch (err) {
+    console.error('Read/write error:', err);
     res.status(500).json({ error: 'Unable to read file' });
   }
 });
@@ -39,15 +40,22 @@ app.post('/api/pages/:page', async (req, res) => {
     await fs.writeFile(file, JSON.stringify(req.body, null, 2));
     res.json({ success: true });
   } catch (err) {
+    console.error('Read/write error:', err);
     res.status(500).json({ error: 'Unable to write file' });
   }
 });
 
 app.post('/api/upload', upload.single('file'), (req, res) => {
-  if (!req.file) {
-    return res.status(400).json({ error: 'No file uploaded' });
+  try {
+    console.log('Uploading:', req.file);
+    if (!req.file) {
+      return res.status(400).json({ error: 'No file uploaded' });
+    }
+    res.json({ path: `/uploads/${req.file.filename}` });
+  } catch (err) {
+    console.error('Upload error:', err);
+    res.status(500).json({ error: 'Upload failed' });
   }
-  res.json({ path: `/uploads/${req.file.filename}` });
 });
 
 const port = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- log read/write errors for `/api/pages/:page` routes
- wrap `/api/upload` route in try/catch and log uploaded file

## Testing
- `npm run lint`
- `node server.js` and `curl -F file=@README.md http://localhost:3001/api/upload`
- `curl http://localhost:3001/api/pages/nonexistent`

------
https://chatgpt.com/codex/tasks/task_e_68c5c50d0a04832197a6beecf4a27ac7