### PR TITLE
Add logging for image uploads in admin panel

### DIFF
--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -125,14 +125,19 @@ export default function Admin() {
     const form = new FormData();
     form.append('file', file);
     try {
+      console.log('Uploading image:', file.name);
       const res = await fetch('/api/upload', {
         method: 'POST',
         body: form,
       });
-      if (res.ok) {
-        const data = await res.json();
-        updateField(path, data.path);
+      if (!res.ok) {
+        console.error('Upload failed:', res.status, await res.text());
+        setError('Failed to upload image');
+        return;
       }
+      const data = await res.json();
+      console.log('Upload succeeded:', data.path);
+      updateField(path, data.path);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Summary
- log when an image upload starts and completes
- report upload failures and surface user-facing error message

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5c50ec034832193b58474dd0e6e15