### PR TITLE
Add scroll-triggered splash screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 import { updatePreviousPathname } from "./utils/navigation";
 
 import PanelGrid from "./components/PanelGrid";
+import SplashScreen from "./components/SplashScreen";
 import Read from "./pages/Read";
 import IssueDetail from "./pages/IssueDetail";
 import Buy from "./pages/Buy";
@@ -26,7 +27,15 @@ export default function App() {
       <LayoutGroup>
         <AnimatePresence mode="wait" initial={false}>
           <Routes location={location} key={location.pathname}>
-            <Route path="/" element={<PanelGrid />} />
+            <Route
+              path="/"
+              element=
+                {(
+                  <SplashScreen>
+                    <PanelGrid />
+                  </SplashScreen>
+                )}
+            />
             <Route path="/read" element={<Read />} />
             <Route path="/read/:issueId" element={<IssueDetail />} />
             <Route path="/buy" element={<Buy />} />

--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -1,0 +1,47 @@
+import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
+
+export default function SplashScreen({ children }) {
+  const [hasScrolled, setHasScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setHasScrolled(true);
+    };
+
+    window.addEventListener("scroll", handleScroll, { once: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <div className="relative h-full w-full overflow-hidden">
+      <motion.img
+        src="/logo.svg"
+        initial={{ opacity: 0, top: "50%", left: "50%", x: "-50%", y: "-50%" }}
+        animate={
+          hasScrolled
+            ? { opacity: 1, top: "1rem", right: "1rem", left: "auto", x: 0, y: 0, scale: 0.5 }
+            : { opacity: 1, top: "50%", left: "50%", x: "-50%", y: "-50%", scale: 1 }
+        }
+        transition={{ duration: 0.5 }}
+        className={`absolute ${hasScrolled ? "logo-top-right" : ""}`}
+      />
+      <motion.p
+        className="absolute left-1/2 top-1/2 mt-16 -translate-x-1/2 text-center"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: hasScrolled ? 0 : 1 }}
+        transition={{ duration: 0.5 }}
+      >
+        Renowned Home
+      </motion.p>
+      <motion.div
+        className="relative h-full w-full"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: hasScrolled ? 1 : 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        {children}
+      </motion.div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -67,5 +67,9 @@ body::before {
   .hero-half {
     @apply w-full h-[50vh] bg-gradient-to-b from-gray-400 to-white;
   }
+
+  .logo-top-right {
+    @apply absolute top-4 right-4;
+  }
 }
 


### PR DESCRIPTION
## Summary
- add animated `SplashScreen` component that fades in the logo and tagline and transitions the logo to the corner on scroll
- wrap home route with `SplashScreen` so `PanelGrid` appears after scrolling
- style top-right logo positioning with new Tailwind class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5c969760c83218aaa5eaa70f4a205