### PR TITLE
Add startup and rendering logs

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,23 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import { logRequest, logSuccess, logError } from "./utils/logger";
+logRequest("App initialization starting");
 
-ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>
-);
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  logError("Root element not found");
+} else {
+  logSuccess("Root element retrieved");
+
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </React.StrictMode>
+  );
+
+  const nodeEnv = import.meta.env?.NODE_ENV || process.env?.NODE_ENV;
+  logSuccess("Rendering started", { nodeEnv });
+}


### PR DESCRIPTION
## Summary
- use shared logger to announce app initialization
- log root element retrieval and rendering start with environment info

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c62649494c8321956bfb71839d6cca