### PR TITLE
feat: add level-based logger with environment control

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import fs from 'fs/promises';
 import path from 'path';
 import multer from 'multer';
+import { logInfo, logError } from './src/utils/logger.js';
 
 const app = express();
 app.use(cors());
@@ -29,7 +30,7 @@ app.get('/api/pages/:page', async (req, res) => {
     const data = await fs.readFile(file, 'utf8');
     res.json(JSON.parse(data));
   } catch (err) {
-    console.error('Read/write error:', err);
+    logError('Read/write error:', err);
     res.status(500).json({ error: 'Unable to read file' });
   }
 });
@@ -40,25 +41,25 @@ app.post('/api/pages/:page', async (req, res) => {
     await fs.writeFile(file, JSON.stringify(req.body, null, 2));
     res.json({ success: true });
   } catch (err) {
-    console.error('Read/write error:', err);
+    logError('Read/write error:', err);
     res.status(500).json({ error: 'Unable to write file' });
   }
 });
 
 app.post('/api/upload', upload.single('file'), (req, res) => {
   try {
-    console.log('Uploading:', req.file);
+    logInfo('Uploading file', req.file);
     if (!req.file) {
       return res.status(400).json({ error: 'No file uploaded' });
     }
     res.json({ path: `/uploads/${req.file.filename}` });
   } catch (err) {
-    console.error('Upload error:', err);
+    logError('Upload error:', err);
     res.status(500).json({ error: 'Upload failed' });
   }
 });
 
 const port = process.env.PORT || 3001;
 app.listen(port, () => {
-  console.log(`API server listening on ${port}`);
+  logInfo(`API server listening on ${port}`);
 });

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,9 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import { logInfo } from "./utils/logger";
+
+logInfo("Initializing React application");
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/src/utils/fetchJson.js
+++ b/src/utils/fetchJson.js
@@ -1,14 +1,14 @@
-import { logError, logRequest, logSuccess } from "./logger";
+import { logDebug, logError, logInfo } from "./logger";
 
 export async function fetchJson(path) {
   try {
-    logRequest("Fetching JSON", { path });
+    logDebug("Fetching JSON", { path });
     const response = await fetch(path);
     if (!response.ok) {
       throw new Error(`Failed to fetch ${path}: ${response.status}`);
     }
     const data = await response.json();
-    logSuccess("Fetched JSON", { path });
+    logInfo("Fetched JSON", { path });
     return data;
   } catch (error) {
     logError(`fetchJson ${path}`, error);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,11 +1,60 @@
-export function logRequest(message, info) {
-  console.info(message, info);
+/**
+ * Simple logging utilities with level filtering and timestamped output.
+ *
+ * Set the desired log level via the `LOG_LEVEL` environment variable on the
+ * server or `VITE_LOG_LEVEL` in the client build. Available levels are
+ * `debug`, `info`, `warn`, and `error` with `info` as the default.
+ *
+ * Each exported function mirrors the native `console` API and prefixes
+ * messages with an ISO timestamp and level tag:
+ *
+ * ```js
+ * import { logInfo } from "./logger";
+ * logInfo("Server started", { port: 8080 });
+ * ```
+ */
+
+const LOG_LEVEL = (
+  (typeof process !== "undefined" && process.env && process.env.LOG_LEVEL) ||
+  (typeof import.meta !== "undefined" &&
+    import.meta.env &&
+    (import.meta.env.VITE_LOG_LEVEL || import.meta.env.LOG_LEVEL)) ||
+  "info"
+);
+
+const LEVELS = { debug: 10, info: 20, warn: 30, error: 40 };
+
+function shouldLog(level) {
+  return LEVELS[level] >= LEVELS[LOG_LEVEL];
 }
 
-export function logSuccess(message, info) {
-  console.info(`Success: ${message}`, info);
+function format(level, message) {
+  const timestamp = new Date().toISOString();
+  return `[${timestamp}] [${level.toUpperCase()}] ${message}`;
 }
 
-export function logError(message, error) {
-  console.error(`Error: ${message}`, error);
+export function logDebug(message, ...optionalParams) {
+  if (shouldLog("debug")) {
+    console.debug(format("debug", message), ...optionalParams);
+  }
 }
+
+export function logInfo(message, ...optionalParams) {
+  if (shouldLog("info")) {
+    console.info(format("info", message), ...optionalParams);
+  }
+}
+
+export function logWarn(message, ...optionalParams) {
+  if (shouldLog("warn")) {
+    console.warn(format("warn", message), ...optionalParams);
+  }
+}
+
+export function logError(message, ...optionalParams) {
+  if (shouldLog("error")) {
+    console.error(format("error", message), ...optionalParams);
+  }
+}
+
+export { LOG_LEVEL };


### PR DESCRIPTION
## Summary
- add timestamped logging utility with debug/info/warn/error helpers and LOG_LEVEL flag
- update fetchJson, app startup, and server code to use new logger

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c6264ceca8832193d2532c4381d10f