### PR TITLE
feat(server): improve logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import fs from 'fs/promises';
 import path from 'path';
 import multer from 'multer';
+import { logRequest, logSuccess, logError } from './src/utils/logger.js';
 
 const app = express();
 app.use(cors());
@@ -10,7 +11,14 @@ app.use(express.json());
 
 const CONTENT_DIR = path.join(process.cwd(), 'content');
 const UPLOAD_DIR = path.join(process.cwd(), 'public/uploads');
+await fs.mkdir(CONTENT_DIR, { recursive: true });
+logSuccess('Content directory ready', { path: CONTENT_DIR });
 await fs.mkdir(UPLOAD_DIR, { recursive: true });
+logSuccess('Upload directory ready', { path: UPLOAD_DIR });
+
+const PORT = process.env.PORT || 3001;
+const NODE_ENV = process.env.NODE_ENV || 'development';
+logRequest('Server environment', { PORT, NODE_ENV });
 
 const storage = multer.diskStorage({
   destination: UPLOAD_DIR,
@@ -29,7 +37,7 @@ app.get('/api/pages/:page', async (req, res) => {
     const data = await fs.readFile(file, 'utf8');
     res.json(JSON.parse(data));
   } catch (err) {
-    console.error('Read/write error:', err);
+    logError('Read/write error', err);
     res.status(500).json({ error: 'Unable to read file' });
   }
 });
@@ -40,25 +48,28 @@ app.post('/api/pages/:page', async (req, res) => {
     await fs.writeFile(file, JSON.stringify(req.body, null, 2));
     res.json({ success: true });
   } catch (err) {
-    console.error('Read/write error:', err);
+    logError('Read/write error', err);
     res.status(500).json({ error: 'Unable to write file' });
   }
 });
 
 app.post('/api/upload', upload.single('file'), (req, res) => {
   try {
-    console.log('Uploading:', req.file);
+    logRequest('Uploading', { file: req.file });
     if (!req.file) {
       return res.status(400).json({ error: 'No file uploaded' });
     }
     res.json({ path: `/uploads/${req.file.filename}` });
   } catch (err) {
-    console.error('Upload error:', err);
+    logError('Upload error', err);
     res.status(500).json({ error: 'Upload failed' });
   }
 });
 
-const port = process.env.PORT || 3001;
-app.listen(port, () => {
-  console.log(`API server listening on ${port}`);
+app.listen(PORT, () => {
+  logSuccess('API server listening', {
+    port: PORT,
+    contentDir: CONTENT_DIR,
+    uploadDir: UPLOAD_DIR,
+  });
 });


### PR DESCRIPTION
## Summary
- log environment variables, content and upload directories at startup
- report directory use on server start and during upload handling with a shared logger

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6265254e4832191a2a6bdff428984