### PR TITLE
fix: safely detect Node environment in browser

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -20,6 +20,8 @@ if (!rootElement) {
     </React.StrictMode>
   );
 
-  const nodeEnv = import.meta.env?.NODE_ENV || process.env?.NODE_ENV;
+  const nodeEnv =
+    import.meta.env?.NODE_ENV ??
+    (typeof process !== "undefined" ? process.env?.NODE_ENV : undefined);
   logSuccess("Rendering started", { nodeEnv });
 }


### PR DESCRIPTION
## Summary
- handle NODE_ENV detection in browser-friendly way

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c63f15161c8321b24cf2d3ca7aec46