### PR TITLE
Use MODE when resolving node environment

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -21,7 +21,7 @@ if (!rootElement) {
   );
 
   const nodeEnv =
-    import.meta.env?.NODE_ENV ??
+    import.meta.env?.MODE ??
     (typeof process !== "undefined" ? process.env?.NODE_ENV : undefined);
   logSuccess("Rendering started", { nodeEnv });
 }


### PR DESCRIPTION
## Summary
- resolve runtime mode from `import.meta.env.MODE` with fallback to `process.env.NODE_ENV`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6410a4424832199d07192b95b6814