### PR TITLE
feat: enable scrolling after splash

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { LayoutGroup, AnimatePresence } from "framer-motion";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { updatePreviousPathname } from "./utils/navigation";
 
@@ -16,13 +16,21 @@ import Breadcrumbs from "./components/Breadcrumbs";
 
 export default function App() {
   const location = useLocation();
+  const [scrollLocked, setScrollLocked] = useState(location.pathname === "/");
 
   useEffect(() => {
     updatePreviousPathname(location.pathname);
+    if (location.pathname !== "/") {
+      setScrollLocked(false);
+    }
   }, [location.pathname]);
 
   return (
-    <div className="fixed inset-0 overflow-hidden p-3 bg-[#fdfaf5]">
+    <div
+      className={`fixed inset-0 p-3 bg-[#fdfaf5] ${
+        scrollLocked ? "overflow-hidden" : "overflow-y-auto"
+      }`}
+    >
       <Breadcrumbs className="absolute top-6 left-6 z-10" />
       <LayoutGroup>
         <AnimatePresence>
@@ -31,7 +39,7 @@ export default function App() {
               path="/"
               element=
                 {(
-                  <SplashScreen>
+                  <SplashScreen onUnlock={() => setScrollLocked(false)}>
                     <PanelGrid />
                   </SplashScreen>
                 )}

--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -1,20 +1,30 @@
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 
-export default function SplashScreen({ children }) {
+export default function SplashScreen({ children, onUnlock }) {
   const [hasScrolled, setHasScrolled] = useState(false);
 
   useEffect(() => {
-    const handleScroll = () => {
+    const handleInteraction = () => {
       setHasScrolled(true);
+      onUnlock?.();
     };
 
-    window.addEventListener("scroll", handleScroll, { once: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+    const opts = { once: true };
+    window.addEventListener("scroll", handleInteraction, opts);
+    window.addEventListener("wheel", handleInteraction, opts);
+    window.addEventListener("touchmove", handleInteraction, opts);
+    return () => {
+      window.removeEventListener("scroll", handleInteraction);
+      window.removeEventListener("wheel", handleInteraction);
+      window.removeEventListener("touchmove", handleInteraction);
+    };
+  }, [onUnlock]);
 
   return (
-    <div className="relative h-full w-full overflow-hidden">
+    <div
+      className={`relative h-full w-full ${hasScrolled ? "" : "overflow-hidden"}`}
+    >
       <motion.img
         src="/logo.svg"
         initial={{ opacity: 0, top: "50%", left: "50%", x: "-50%", y: "-50%" }}


### PR DESCRIPTION
## Summary
- allow main app container to scroll once splash is dismissed by toggling overflow classes
- trigger splash fade-in on scroll, wheel or touchmove and unlock body when interaction occurs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6447b3f9883218e74b1543a2ad031