### PR TITLE
Refine layout animations for transitions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,7 @@ export default function App() {
     >
       <Breadcrumbs className="absolute top-6 left-6 z-10" />
       <LayoutGroup>
-        <AnimatePresence>
+        <AnimatePresence mode="wait">
           <Routes location={location} key={location.pathname}>
             <Route
               path="/"

--- a/src/components/Panel.jsx
+++ b/src/components/Panel.jsx
@@ -2,10 +2,11 @@ import { motion } from "framer-motion";
 
 export default function Panel({ id, children, centerChildren = true }) {
   return (
-    <motion.div
-      layoutId={`panel-${id}`}
-      className="w-full h-full border border-black rounded-lg overflow-hidden"
-    >
+    <div className="w-full h-full relative rounded-lg overflow-hidden">
+      <motion.div
+        layoutId={`panel-${id}`}
+        className="absolute inset-0 border border-black rounded-lg pointer-events-none"
+      />
       <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6">
         <div
           className={["flex-1", centerChildren ? "flex items-center justify-center" : ""].join(" ")}
@@ -13,6 +14,6 @@ export default function Panel({ id, children, centerChildren = true }) {
           {children}
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -40,12 +40,11 @@ export default function PanelCard({
         className="absolute inset-0 border border-black rounded-lg flex items-center justify-center pointer-events-none"
       >
         {label && (
-          <motion.span
-            layoutId={label}
+          <span
             className="relative z-10 text-black group-hover:text-white transition-colors duration-300 font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}
-          </motion.span>
+          </span>
         )}
       </motion.div>
     </motion.div>


### PR DESCRIPTION
## Summary
- wait for exit animations before mounting new routes
- restrict layoutId to panel borders to avoid unwanted movement
- remove layoutId from panel card labels to prevent stray animations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c646dda1588321898dcefa6f2eb620