### PR TITLE
Replay splash screen on every load and move logo

### DIFF
--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -2,16 +2,13 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useState } from "react";
 
 export default function SplashScreen({ children, onUnlock }) {
-  const [hasScrolled, setHasScrolled] = useState(
-    () => sessionStorage.getItem("homeVisited") === "true"
-  );
-  const [showSplash, setShowSplash] = useState(!hasScrolled);
+  const [hasScrolled, setHasScrolled] = useState(false);
+  const [showSplash, setShowSplash] = useState(true);
 
   useEffect(() => {
     if (hasScrolled) return;
 
     const handleScroll = () => {
-      sessionStorage.setItem("homeVisited", "true");
       setHasScrolled(true);
       onUnlock?.();
     };
@@ -28,47 +25,44 @@ export default function SplashScreen({ children, onUnlock }) {
 
   return (
     <div className={`relative h-full w-full ${showSplash ? "overflow-hidden" : ""}`}>
+      <motion.img
+        key="logo"
+        src="/logo.svg"
+        initial={{ opacity: 0, top: "50%", left: "50%", x: "-50%", y: "-50%" }}
+        animate=
+          {hasScrolled
+            ? {
+                opacity: 1,
+                top: "1.5rem",
+                right: "1.5rem",
+                left: "auto",
+                x: 0,
+                y: 0,
+                scale: 0.5,
+              }
+            : {
+                opacity: 1,
+                top: "50%",
+                left: "50%",
+                x: "-50%",
+                y: "-50%",
+                scale: 1,
+              }}
+        transition={{ duration: 0.5 }}
+        className={`absolute ${hasScrolled ? "logo-top-right" : ""}`}
+      />
       <AnimatePresence>
         {showSplash && (
-          <>
-            <motion.img
-              key="logo"
-              src="/logo.svg"
-              initial={{ opacity: 0, top: "50%", left: "50%", x: "-50%", y: "-50%" }}
-              animate=
-                {hasScrolled
-                  ? {
-                      opacity: 1,
-                      top: "1rem",
-                      right: "1rem",
-                      left: "auto",
-                      x: 0,
-                      y: 0,
-                      scale: 0.5,
-                    }
-                  : {
-                      opacity: 1,
-                      top: "50%",
-                      left: "50%",
-                      x: "-50%",
-                      y: "-50%",
-                      scale: 1,
-                    }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.5 }}
-              className={`absolute ${hasScrolled ? "logo-top-right" : ""}`}
-            />
-            <motion.p
-              key="text"
-              className="absolute left-1/2 top-1/2 mt-16 -translate-x-1/2 text-center"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.5 }}
-            >
-              Renowned Home
-            </motion.p>
-          </>
+          <motion.p
+            key="text"
+            className="absolute left-1/2 top-1/2 mt-16 -translate-x-1/2 text-center"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            Renowned Home
+          </motion.p>
         )}
       </AnimatePresence>
       <motion.div

--- a/src/index.css
+++ b/src/index.css
@@ -69,7 +69,7 @@ body::before {
   }
 
   .logo-top-right {
-    @apply absolute top-4 right-4;
+    @apply absolute top-6 right-6 z-10;
   }
 }
 


### PR DESCRIPTION
## Summary
- Always display the splash screen on every visit by removing session storage checks.
- Keep logo visible after scrolling and animate it to a small top-right position aligned with breadcrumbs.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7606a8fa48321953125873b87bf5b