### PR TITLE
Refine splash screen animations and layering

### DIFF
--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -1,37 +1,62 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-export default function SplashScreen({ children, onUnlock }) {
-  const [hasScrolled, setHasScrolled] = useState(false);
-  const [showSplash, setShowSplash] = useState(true);
+export default function SplashScreen({
+  children,
+  onUnlock,
+  logoSrc = "/logo.svg",
+  subtitle = "Renowned Home",
+}) {
+  const [isAtTop, setIsAtTop] = useState(true);
+  const unlockedRef = useRef(false);
 
   useEffect(() => {
-    if (hasScrolled) return;
-
     const handleScroll = () => {
-      setHasScrolled(true);
-      onUnlock?.();
+      const atTop = window.scrollY === 0;
+      setIsAtTop(atTop);
+      if (!unlockedRef.current && !atTop) {
+        unlockedRef.current = true;
+        onUnlock?.();
+      }
     };
-
-    window.addEventListener("scroll", handleScroll, { once: true });
+    window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
-  }, [hasScrolled, onUnlock]);
+  }, [onUnlock]);
 
-  useEffect(() => {
-    if (!hasScrolled) return;
-    const timeout = setTimeout(() => setShowSplash(false), 500);
-    return () => clearTimeout(timeout);
-  }, [hasScrolled]);
+  const words = subtitle.split(" ");
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        delayChildren: 0.5,
+        staggerChildren: words.length ? 1.5 / words.length : 0,
+      },
+    },
+    exit: { opacity: 0 },
+  };
+  const wordVariants = {
+    hidden: { opacity: 0 },
+    visible: { opacity: 1, transition: { duration: 0.5 } },
+  };
 
   return (
-    <div className={`relative h-full w-full ${showSplash ? "overflow-hidden" : ""}`}>
+    <div className="relative h-full w-full">
       <motion.img
         key="logo"
-        src="/logo.svg"
+        src={logoSrc}
         initial={{ opacity: 0, top: "50%", left: "50%", x: "-50%", y: "-50%" }}
         animate=
-          {hasScrolled
+          isAtTop
             ? {
+                opacity: 1,
+                top: "50%",
+                left: "50%",
+                x: "-50%",
+                y: "-50%",
+                scale: 1,
+              }
+            : {
                 opacity: 1,
                 top: "1.5rem",
                 right: "1.5rem",
@@ -40,35 +65,35 @@ export default function SplashScreen({ children, onUnlock }) {
                 y: 0,
                 scale: 0.5,
               }
-            : {
-                opacity: 1,
-                top: "50%",
-                left: "50%",
-                x: "-50%",
-                y: "-50%",
-                scale: 1,
-              }}
         transition={{ duration: 0.5 }}
-        className={`absolute ${hasScrolled ? "logo-top-right" : ""}`}
+        className="absolute z-50 pointer-events-none"
       />
       <AnimatePresence>
-        {showSplash && (
+        {isAtTop && (
           <motion.p
             key="text"
-            className="absolute left-1/2 top-1/2 mt-16 -translate-x-1/2 text-center"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.5 }}
+            className="absolute left-1/2 top-1/2 mt-16 -translate-x-1/2 text-center z-40"
+            variants={containerVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
           >
-            Renowned Home
+            {words.map((word, idx) => (
+              <motion.span
+                key={idx}
+                variants={wordVariants}
+                className="inline-block mr-2"
+              >
+                {word}
+              </motion.span>
+            ))}
           </motion.p>
         )}
       </AnimatePresence>
       <motion.div
         className="relative h-full w-full"
-        initial={{ opacity: showSplash ? 0 : 1 }}
-        animate={{ opacity: 1 }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: isAtTop ? 0 : 1 }}
         transition={{ duration: 0.5 }}
       >
         {children}

--- a/src/index.css
+++ b/src/index.css
@@ -68,8 +68,5 @@ body::before {
     @apply w-full h-[50vh] bg-gradient-to-b from-gray-400 to-white;
   }
 
-  .logo-top-right {
-    @apply absolute top-6 right-6 z-10;
-  }
 }
 


### PR DESCRIPTION
## Summary
- rework splash screen to track scroll position and unlock on first scroll
- animate subtitle words sequentially after logo fade-in
- ensure logo stays above panels and remove obsolete logo-top-right style

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c7671f8c148321a5354351b8d2a7f7