### PR TITLE
Animate issue transition to detail view

### DIFF
--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -12,24 +12,26 @@ export default function IssueCarousel({ issues = [] }) {
       <div className="flex space-x-4 p-4">
         {issues.map((issue) => (
           <Link key={issue.order} to={`/read/${issue.order}`} className="block">
-            <motion.div
-              layoutId={`panel-issue-${issue.order}`}
+            <div
               className="flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden w-[150px] sm:w-[200px] cursor-pointer"
               style={{ borderColor: "var(--border)" }}
             >
-              <div className="w-full aspect-square">
+              <motion.div
+                layoutId={`issue-image-${issue.order}`}
+                className="w-full aspect-square"
+              >
                 <ImageWithFallback
                   src={issue.thumbnail}
                   alt={issue.title}
                   className="w-full h-full object-cover"
                 />
-              </div>
+              </motion.div>
               <div className="p-2 text-center">
                 <p className="text-sm font-medium text-[var(--foreground)]">
                   {issue.title}
                 </p>
               </div>
-            </motion.div>
+            </div>
           </Link>
         ))}
       </div>

--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -1,5 +1,22 @@
 import { motion } from "framer-motion";
 
+const containerVariants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.2, delayChildren: 0.1 },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: -10 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: "easeOut" },
+  },
+};
+
 export default function IssueInfoPanel({ issue }) {
   if (!issue) {
     return null;
@@ -10,26 +27,33 @@ export default function IssueInfoPanel({ issue }) {
   return (
     <motion.div
       key={issue.id}
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 20 }}
+      variants={containerVariants}
+      initial="hidden"
+      animate="show"
       className="flex flex-col gap-4 mt-6 w-full"
     >
-      <div className="text-center">
-        <h1 className="text-3xl font-bold">{title}</h1>
-        {(issue.writer || issue.artist || issue.colorist) && (
-          <div className="mt-2 text-sm text-gray-500">
-            {issue.writer && <p>Writer: {issue.writer}</p>}
-            {issue.artist && <p>Artist: {issue.artist}</p>}
-            {issue.colorist && <p>Colorist: {issue.colorist}</p>}
-          </div>
-        )}
-      </div>
+      <motion.h1 variants={itemVariants} className="text-3xl font-bold text-center">
+        {title}
+      </motion.h1>
+      {(issue.writer || issue.artist || issue.colorist) && (
+        <motion.div
+          variants={itemVariants}
+          className="mt-2 text-sm text-gray-500 text-center"
+        >
+          {issue.writer && <p>Writer: {issue.writer}</p>}
+          {issue.artist && <p>Artist: {issue.artist}</p>}
+          {issue.colorist && <p>Colorist: {issue.colorist}</p>}
+        </motion.div>
+      )}
       {issue.subtitle && (
-        <h2 className="text-gray-500 text-left">{issue.subtitle}</h2>
+        <motion.h2 variants={itemVariants} className="text-gray-500 text-left">
+          {issue.subtitle}
+        </motion.h2>
       )}
       {issue.description && (
-        <p className="text-left text-black">{issue.description}</p>
+        <motion.p variants={itemVariants} className="text-left text-black">
+          {issue.description}
+        </motion.p>
       )}
     </motion.div>
   );

--- a/src/pages/IssueDetail.jsx
+++ b/src/pages/IssueDetail.jsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router-dom";
+import { motion } from "framer-motion";
 import Panel from "../components/Panel";
 import ImageWithFallback from "../components/ImageWithFallback";
 import IssueInfoPanel from "../components/IssueInfoPanel";
@@ -20,7 +21,10 @@ export default function IssueDetail() {
     <Panel id={`issue-${issueId}`} centerChildren={false}>
       <div className="flex flex-col">
         {issue.heroImage && (
-          <div className="w-full h-[50vh] overflow-hidden">
+          <motion.div
+            layoutId={`issue-image-${issue.order}`}
+            className="w-full h-[50vh] overflow-hidden"
+          >
             <ImageWithFallback
               src={issue.heroImage}
               alt={issue.title}
@@ -32,7 +36,7 @@ export default function IssueDetail() {
                   "linear-gradient(to bottom, black 50%, transparent 100%)",
               }}
             />
-          </div>
+          </motion.div>
         )}
         <IssueInfoPanel issue={issue} />
       </div>


### PR DESCRIPTION
## Summary
- Animate issue thumbnails into hero images for detail views
- Stagger fade-in for issue detail content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7679e31c083219e8ba15e81b3ea01