### PR TITLE
Restore panel label transforms using internal layout IDs

### DIFF
--- a/content/buy.json
+++ b/content/buy.json
@@ -7,7 +7,6 @@
   },
   "hero": {
     "heading": {
-      "layoutId": "BUY",
       "text": "BUY",
       "className": "text-black font-bold uppercase",
       "size": "text-[clamp(3rem,8vw,10rem)]"

--- a/content/connect.json
+++ b/content/connect.json
@@ -7,7 +7,6 @@
   },
   "hero": {
     "heading": {
-      "layoutId": "CONNECT",
       "text": "CONNECT",
       "className": "text-black font-bold uppercase",
       "size": "text-[clamp(3rem,8vw,10rem)]"

--- a/content/meet.json
+++ b/content/meet.json
@@ -7,7 +7,6 @@
   },
   "hero": {
     "heading": {
-      "layoutId": "MEET",
       "text": "MEET",
       "className": "text-black font-bold uppercase",
       "size": "text-[clamp(3rem,8vw,10rem)]"

--- a/content/read.json
+++ b/content/read.json
@@ -7,7 +7,6 @@
   },
   "hero": {
     "heading": {
-      "layoutId": "READ",
       "text": "READ",
       "className": "text-black font-bold uppercase",
       "size": "text-[clamp(3rem,8vw,10rem)]"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,7 @@ export default function App() {
     >
       <Breadcrumbs className="absolute top-6 left-6 z-10" />
       <LayoutGroup>
-        <AnimatePresence mode="wait">
+        <AnimatePresence>
           <Routes location={location} key={location.pathname}>
             <Route
               path="/"

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -40,11 +40,12 @@ export default function PanelCard({
         className="absolute inset-0 border border-black rounded-lg flex items-center justify-center pointer-events-none"
       >
         {label && (
-          <span
+          <motion.span
+            layoutId={`panel-label-${label}`}
             className="relative z-10 text-black group-hover:text-white transition-colors duration-300 font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}
-          </span>
+          </motion.span>
         )}
       </motion.div>
     </motion.div>

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -12,7 +12,7 @@ export default function Buy() {
     <Panel id={panel.main.name}>
       <div className="flex flex-col items-center">
         <motion.h1
-          layoutId={heading.layoutId}
+          layoutId={`panel-label-${panel.main.name}`}
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -12,7 +12,7 @@ export default function Connect() {
     <Panel id={panel.main.name}>
       <div className="flex flex-col items-center">
         <motion.h1
-          layoutId={heading.layoutId}
+          layoutId={`panel-label-${panel.main.name}`}
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -12,7 +12,7 @@ export default function Meet() {
     <Panel id={panel.main.name}>
       <div className="flex flex-col items-center">
         <motion.h1
-          layoutId={heading.layoutId}
+          layoutId={`panel-label-${panel.main.name}`}
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -14,7 +14,7 @@ export default function Read() {
     <Panel id={panel.main.name} centerChildren={false}>
       <div className="flex flex-col items-center">
         <motion.h1
-          layoutId={heading.layoutId}
+          layoutId={`panel-label-${panel.main.name}`}
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}


### PR DESCRIPTION
## Summary
- Reinstate label-to-heading transforms by assigning layout IDs to panel labels
- Compute heading layout IDs from panel names and drop layoutId from content
- Allow overlapping route transitions by removing AnimatePresence wait mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7673e3e6883218e7cfef6af161939