### PR TITLE
Add interactive splash screen overlay

### DIFF
--- a/content/splash.json
+++ b/content/splash.json
@@ -1,0 +1,4 @@
+{
+  "logoSrc": "/logo.svg",
+  "subtitle": "Renowned Home"
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { LayoutGroup, AnimatePresence } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { updatePreviousPathname } from "./utils/navigation";
 
@@ -16,14 +16,10 @@ import Breadcrumbs from "./components/Breadcrumbs";
 
 export default function App() {
   const location = useLocation();
-  const [scrollLocked, setScrollLocked] = useState(location.pathname === "/");
-
   useEffect(() => {
     updatePreviousPathname(location.pathname);
-    if (location.pathname !== "/") {
-      setScrollLocked(false);
-    }
   }, [location.pathname]);
+  const scrollLocked = location.pathname === "/";
 
   return (
     <div
@@ -39,7 +35,7 @@ export default function App() {
               path="/"
               element=
                 {(
-                  <SplashScreen onUnlock={() => setScrollLocked(false)}>
+                  <SplashScreen>
                     <PanelGrid />
                   </SplashScreen>
                 )}

--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -1,27 +1,20 @@
+import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useRef, useState } from "react";
+import content from "../../content/splash.json";
 
-export default function SplashScreen({
-  children,
-  onUnlock,
-  logoSrc = "/logo.svg",
-  subtitle = "Renowned Home",
-}) {
-  const [isAtTop, setIsAtTop] = useState(true);
-  const unlockedRef = useRef(false);
+export default function SplashScreen({ children }) {
+  const { logoSrc, subtitle } = content;
+  const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
-    const handleScroll = () => {
-      const atTop = window.scrollY === 0;
-      setIsAtTop(atTop);
-      if (!unlockedRef.current && !atTop) {
-        unlockedRef.current = true;
-        onUnlock?.();
-      }
+    const handleDismiss = () => setDismissed(true);
+    window.addEventListener("wheel", handleDismiss, { once: true });
+    window.addEventListener("touchmove", handleDismiss, { once: true });
+    return () => {
+      window.removeEventListener("wheel", handleDismiss);
+      window.removeEventListener("touchmove", handleDismiss);
     };
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, [onUnlock]);
+  }, []);
 
   const words = subtitle.split(" ");
   const containerVariants = {
@@ -42,63 +35,43 @@ export default function SplashScreen({
 
   return (
     <div className="relative h-full w-full">
-     <motion.img
-  key="logo"
-  src={logoSrc}
-  initial={{ opacity: 0, top: "50%", left: "50%", x: "-50%", y: "-50%" }}
-  animate={
-    isAtTop
-      ? {
-          opacity: 1,
-          top: "50%",
-          left: "50%",
-          x: "-50%",
-          y: "-50%",
-          scale: 1,
-        }
-      : {
-          opacity: 1,
-          top: "1.5rem",
-          right: "1.5rem",
-          left: "auto",
-          x: 0,
-          y: 0,
-          scale: 0.5,
-        }
-  }
-  transition={{ duration: 0.5 }}
-  className="absolute z-50 pointer-events-none"
-/>
       <AnimatePresence>
-        {isAtTop && (
-          <motion.p
-            key="text"
-            className="absolute left-1/2 top-1/2 mt-16 -translate-x-1/2 text-center z-40"
-            variants={containerVariants}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
+        {!dismissed && (
+          <motion.div
+            key="splash"
+            className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-[#fdfaf5]"
+            initial={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
           >
-            {words.map((word, idx) => (
-              <motion.span
-                key={idx}
-                variants={wordVariants}
-                className="inline-block mr-2"
-              >
-                {word}
-              </motion.span>
-            ))}
-          </motion.p>
+            <motion.img
+              src={logoSrc}
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.8 }}
+              transition={{ duration: 0.5 }}
+              className="mb-8"
+            />
+            <motion.p
+              className="text-center"
+              variants={containerVariants}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+            >
+              {words.map((word, idx) => (
+                <motion.span
+                  key={idx}
+                  variants={wordVariants}
+                  className="inline-block mr-2"
+                >
+                  {word}
+                </motion.span>
+              ))}
+            </motion.p>
+          </motion.div>
         )}
       </AnimatePresence>
-      <motion.div
-        className="relative h-full w-full"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: isAtTop ? 0 : 1 }}
-        transition={{ duration: 0.5 }}
-      >
-        {children}
-      </motion.div>
+      {children}
     </div>
   );
 }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD || "admin";
 const PAGES = [
+  { id: "splash", name: "Splash Screen" },
   { id: "read", name: "Read" },
   { id: "buy", name: "Buy" },
   { id: "meet", name: "Meet" },


### PR DESCRIPTION
## Summary
- add editable splash screen content and admin page entry
- implement dismissible splash overlay triggered by first scroll
- simplify app scroll locking for static homepage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c76a6d54008321b8c49b65ae03c109