### PR TITLE
Smooth panel transitions from home to subpages

### DIFF
--- a/src/components/Panel.jsx
+++ b/src/components/Panel.jsx
@@ -5,6 +5,7 @@ export default function Panel({ id, children, centerChildren = true }) {
     <div className="w-full h-full relative rounded-lg overflow-hidden">
       <motion.div
         layoutId={`panel-${id}`}
+        transition={{ duration: 0.4 }}
         className="absolute inset-0 border border-black rounded-lg pointer-events-none"
       />
       <div className="h-full overflow-y-auto flex flex-col px-6 pt-10 pb-6">

--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -25,7 +25,8 @@ export default function PanelCard({
         <motion.div
           initial={isTransforming ? { opacity: 0 } : undefined}
           animate={isTransforming ? { opacity: 1 } : undefined}
-          transition={isTransforming ? { delay: fadeDelay, duration: 0.4 } : undefined}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.4, delay: isTransforming ? fadeDelay : 0 }}
           className="absolute inset-0 w-full h-full"
         >
           <ImageWithFallback
@@ -37,11 +38,13 @@ export default function PanelCard({
       )}
       <motion.div
         layoutId={`panel-${label}`}
+        transition={{ duration: 0.4 }}
         className="absolute inset-0 border border-black rounded-lg flex items-center justify-center pointer-events-none"
       >
         {label && (
           <motion.span
             layoutId={`panel-label-${label}`}
+            transition={{ duration: 0.4 }}
             className="relative z-10 text-black group-hover:text-white transition-colors duration-300 font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -13,6 +13,7 @@ export default function Buy() {
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
+          transition={{ duration: 0.4 }}
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -13,6 +13,7 @@ export default function Connect() {
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
+          transition={{ duration: 0.4 }}
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -13,6 +13,7 @@ export default function Meet() {
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
+          transition={{ duration: 0.4 }}
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -15,6 +15,7 @@ export default function Read() {
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
+          transition={{ duration: 0.4 }}
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}


### PR DESCRIPTION
## Summary
- fade out panel images during navigation for a seamless transition
- synchronize panel borders and labels with consistent motion timing
- unify subpage headings with shared layout transitions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c76afc3d688321b4985dd025a89133