### PR TITLE
Skip splash screen when returning from subpages

### DIFF
--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -1,12 +1,16 @@
 import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import content from "../../content/splash.json";
+import { getPreviousPathname } from "../utils/navigation";
 
 export default function SplashScreen({ children }) {
   const { logoSrc, subtitle } = content;
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissed, setDismissed] = useState(
+    () => getPreviousPathname() !== "/"
+  );
 
   useEffect(() => {
+    if (dismissed) return;
     const handleDismiss = () => setDismissed(true);
     window.addEventListener("wheel", handleDismiss, { once: true });
     window.addEventListener("touchmove", handleDismiss, { once: true });
@@ -14,7 +18,7 @@ export default function SplashScreen({ children }) {
       window.removeEventListener("wheel", handleDismiss);
       window.removeEventListener("touchmove", handleDismiss);
     };
-  }, []);
+  }, [dismissed]);
 
   const words = subtitle.split(" ");
   const containerVariants = {


### PR DESCRIPTION
## Summary
- Hide splash screen when navigating back to home by checking previously visited path
- Avoid mounting dismissal handlers when splash is already skipped

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c76c5199d48321b8dad7cad74654e0