### PR TITLE
Constrain splash logo size

### DIFF
--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -53,7 +53,7 @@ export default function SplashScreen({ children }) {
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.8 }}
               transition={{ duration: 0.5 }}
-              className="mb-8"
+              className="mb-4 h-24 w-24"
             />
             <motion.p
               className="text-center"


### PR DESCRIPTION
## Summary
- enforce fixed dimensions on splash logo so it remains small

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7718673ec8321b5a56b60fbc830e7