### PR TITLE
Prevent splash screen from reappearing after navigation

### DIFF
--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -1,16 +1,18 @@
 import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import content from "../../content/splash.json";
-import { getPreviousPathname } from "../utils/navigation";
+
+let hasShownSplash = false;
 
 export default function SplashScreen({ children }) {
   const { logoSrc, subtitle } = content;
-  const [dismissed, setDismissed] = useState(
-    () => getPreviousPathname() !== "/"
-  );
+  const [dismissed, setDismissed] = useState(() => hasShownSplash);
 
   useEffect(() => {
-    if (dismissed) return;
+    if (dismissed) {
+      hasShownSplash = true;
+      return;
+    }
     const handleDismiss = () => setDismissed(true);
     window.addEventListener("wheel", handleDismiss, { once: true });
     window.addEventListener("touchmove", handleDismiss, { once: true });


### PR DESCRIPTION
## Summary
- Track splash screen dismissal with a module-level flag so the splash only appears on first load or refresh

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c771af572c83218559897476e2b453