### PR TITLE
style: raise header nav

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ export default function App() {
         scrollLocked ? "overflow-hidden" : "overflow-y-auto"
       }`}
     >
-      <header className="absolute top-6 left-6 right-6 z-10 flex items-center justify-between">
+      <header className="absolute top-3 left-6 right-6 z-10 flex items-center justify-between">
         <Breadcrumbs />
         <AnimatePresence>
           {logoVisible && (


### PR DESCRIPTION
## Summary
- Move header breadcrumbs and corner logo higher to avoid overlapping home page panels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7760ca9e083219077e60afc6cda3d