### PR TITLE
style: simplify home panel labels

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -45,7 +45,7 @@ export default function PanelCard({
           <motion.span
             layoutId={`panel-label-${label}`}
             transition={{ duration: 0.4 }}
-            className="relative z-10 text-black group-hover:text-white transition-colors duration-300 font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
+            className="relative z-10 text-white transition-transform duration-700 ease-out group-hover:scale-105 font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}
           </motion.span>


### PR DESCRIPTION
## Summary
- default home panel label text to white
- add gentle hover scale with slow ease-out

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c77782d1088321b240deb7968d3294