### PR TITLE
Add bio tiles and detail pages to Meet section

### DIFF
--- a/content/meet.json
+++ b/content/meet.json
@@ -16,5 +16,13 @@
       "className": "mt-2 text-center font-sans",
       "size": "text-8xl"
     }
-  }
+  },
+  "bios": [
+    {
+      "name": "Name",
+      "image": "/uploads/placeholder.png",
+      "biography": "Biography",
+      "works": "Work 1, Work 2"
+    }
+  ]
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import Read from "./pages/Read";
 import IssueDetail from "./pages/IssueDetail";
 import Buy from "./pages/Buy";
 import Meet from "./pages/Meet";
+import BioDetail from "./pages/BioDetail";
 import Connect from "./pages/Connect";
 import Admin from "./pages/Admin";
 import Breadcrumbs from "./components/Breadcrumbs";
@@ -65,6 +66,7 @@ export default function App() {
               <Route path="/read/:issueId" element={<Page><IssueDetail /></Page>} />
               <Route path="/buy" element={<Page><Buy /></Page>} />
               <Route path="/meet" element={<Page><Meet /></Page>} />
+              <Route path="/meet/:bioId" element={<Page><BioDetail /></Page>} />
               <Route path="/connect" element={<Page><Connect /></Page>} />
               <Route path="/admin" element={<Page><Admin /></Page>} />
               <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/BioCarousel.jsx
+++ b/src/components/BioCarousel.jsx
@@ -1,0 +1,41 @@
+import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
+import ImageWithFallback from "./ImageWithFallback";
+
+export default function BioCarousel({ bios = [] }) {
+  if (!bios.length) {
+    return <div>No bios available.</div>;
+  }
+
+  return (
+    <div className="w-full overflow-x-auto touch-pan-x">
+      <div className="flex space-x-4 p-4">
+        {bios.map((bio, index) => (
+          <Link key={index} to={`/meet/${index}`} className="block">
+            <div
+              className={[
+                "flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden",
+                "w-[150px] sm:w-[200px] cursor-pointer",
+              ].join(" ")}
+              style={{ borderColor: "var(--border)" }}
+            >
+              <motion.div layoutId={`bio-image-${index}`} className="w-full aspect-square">
+                <ImageWithFallback
+                  src={bio.image}
+                  alt={bio.name}
+                  className="w-full h-full object-cover"
+                />
+              </motion.div>
+              <div className="p-2 text-center">
+                <p className="text-sm font-medium text-[var(--foreground)]">
+                  {bio.name}
+                </p>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/BioInfoPanel.jsx
+++ b/src/components/BioInfoPanel.jsx
@@ -1,0 +1,61 @@
+import { motion } from "framer-motion";
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.2, delayChildren: 0.1 },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: -10 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: "easeOut" },
+  },
+};
+
+export default function BioInfoPanel({ bio }) {
+  if (!bio) {
+    return null;
+  }
+
+  const works = Array.isArray(bio.works)
+    ? bio.works
+    : bio.works
+        .split(",")
+        .map((w) => w.trim())
+        .filter(Boolean);
+
+  return (
+    <motion.div
+      key={bio.name}
+      variants={containerVariants}
+      initial="hidden"
+      animate="show"
+      className="flex flex-col gap-4 mt-6 w-full"
+    >
+      <motion.h1 variants={itemVariants} className="text-3xl font-bold text-center">
+        {bio.name}
+      </motion.h1>
+      {bio.biography && (
+        <motion.p variants={itemVariants} className="text-left text-black">
+          {bio.biography}
+        </motion.p>
+      )}
+      {works.length > 0 && (
+        <motion.ul
+          variants={itemVariants}
+          className="text-left text-gray-500 list-disc pl-5"
+        >
+          {works.map((work, idx) => (
+            <li key={idx}>{work}</li>
+          ))}
+        </motion.ul>
+      )}
+    </motion.div>
+  );
+}
+

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -201,6 +201,14 @@ export default function Admin() {
         thumbnail: '/uploads/placeholder.png',
       };
     }
+    if (joined === 'bios') {
+      return {
+        name: 'Name',
+        image: '/uploads/placeholder.png',
+        biography: 'Biography',
+        works: 'Work 1, Work 2',
+      };
+    }
     return '';
   };
 

--- a/src/pages/BioDetail.jsx
+++ b/src/pages/BioDetail.jsx
@@ -1,0 +1,46 @@
+import { useParams } from "react-router-dom";
+import { motion } from "framer-motion";
+import Panel from "../components/Panel";
+import ImageWithFallback from "../components/ImageWithFallback";
+import BioInfoPanel from "../components/BioInfoPanel";
+import content from "../../content/meet.json";
+
+export default function BioDetail() {
+  const { bioId } = useParams();
+  const bio = content.bios?.[Number(bioId)];
+
+  if (!bio) {
+    return (
+      <Panel id={`bio-${bioId}`}>
+        <div className="text-center">Bio not found.</div>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel id={`bio-${bioId}`} centerChildren={false}>
+      <div className="flex flex-col">
+        {bio.image && (
+          <motion.div
+            layoutId={`bio-image-${bioId}`}
+            className="w-full h-[50vh] overflow-hidden"
+          >
+            <ImageWithFallback
+              src={bio.image}
+              alt={bio.name}
+              className="w-full h-full object-cover"
+              style={{
+                WebkitMaskImage:
+                  "linear-gradient(to bottom, black 50%, transparent 100%)",
+                maskImage:
+                  "linear-gradient(to bottom, black 50%, transparent 100%)",
+              }}
+            />
+          </motion.div>
+        )}
+        <BioInfoPanel bio={bio} />
+      </div>
+    </Panel>
+  );
+}
+

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -1,15 +1,17 @@
 import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import BioCarousel from "../components/BioCarousel";
 import content from "../../content/meet.json";
 
 export default function Meet() {
   const {
     panel,
     hero: { heading, subtitle },
+    bios = [],
   } = content;
 
   return (
-    <Panel id={panel.main.name}>
+    <Panel id={panel.main.name} centerChildren={false}>
       <div className="flex flex-col items-center">
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
@@ -24,6 +26,7 @@ export default function Meet() {
           </p>
         )}
       </div>
+      {bios.length > 0 && <BioCarousel bios={bios} />}
     </Panel>
   );
 }


### PR DESCRIPTION
## Summary
- Display bios on Meet page using new carousel
- Add bio detail view with hero image, biography and works list
- Support editing bios via admin placeholders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c77d92dbe48321a85fdd97570c2686