### PR TITLE
Fix read page label transform alignment

### DIFF
--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -12,7 +12,7 @@ export default function Read() {
 
   return (
     <Panel id={panel.main.name} centerChildren={false}>
-      <div className="flex flex-col items-center">
+      <div className="flex flex-col items-center w-full">
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
           transition={{ duration: 0.4 }}
@@ -25,8 +25,8 @@ export default function Read() {
             {subtitle.text}
           </p>
         )}
+        {issues.length > 0 && <IssueCarousel issues={issues} />}
       </div>
-      {issues.length > 0 && <IssueCarousel issues={issues} />}
     </Panel>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap read page heading and carousel in a single container so label transforms to the correct position

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c77bbe40cc8321b948cc57ab00318c