### PR TITLE
feat: enhance connect page with signup and icons

### DIFF
--- a/content/connect.json
+++ b/content/connect.json
@@ -16,5 +16,22 @@
       "className": "mt-2 text-center font-sans",
       "size": "text-8xl"
     }
-  }
+  },
+  "icons": [
+    {
+      "id": 1,
+      "link": "",
+      "image": "/uploads/placeholder.png"
+    },
+    {
+      "id": 2,
+      "link": "",
+      "image": "/uploads/placeholder.png"
+    },
+    {
+      "id": 3,
+      "link": "",
+      "image": "/uploads/placeholder.png"
+    }
+  ]
 }

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -6,6 +6,7 @@ export default function Connect() {
   const {
     panel,
     hero: { heading, subtitle },
+    icons = [],
   } = content;
 
   return (
@@ -22,6 +23,28 @@ export default function Connect() {
           <p className={`${subtitle.className} ${subtitle.size}`}>
             {subtitle.text}
           </p>
+        )}
+        <div
+          data-supascribe-embed-id="478951807419"
+          data-supascribe-subscribe
+          className="mt-4"
+        />
+        {icons.length > 0 && (
+          <div className="flex gap-4 mt-8">
+            {icons.map((icon) => (
+              <a
+                key={icon.id}
+                href={icon.link || "#"}
+                className="w-24 h-24"
+              >
+                <img
+                  src={icon.image}
+                  alt={`icon-${icon.id}`}
+                  className="w-full h-full object-cover rounded-full"
+                />
+              </a>
+            ))}
+          </div>
         )}
       </div>
     </Panel>


### PR DESCRIPTION
## Summary
- embed Supascribe signup form on connect page
- display three admin-configurable circular icons

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7800431848321a07df63a2a5855ae