### PR TITLE
feat: make issue and bio IDs editable

### DIFF
--- a/content/meet.json
+++ b/content/meet.json
@@ -19,6 +19,7 @@
   },
   "bios": [
     {
+      "id": 1,
       "name": "Name",
       "image": "/uploads/placeholder.png",
       "biography": "Biography",

--- a/content/read.json
+++ b/content/read.json
@@ -19,6 +19,7 @@
   },
   "issues": [
     {
+      "id": 1,
       "order": 1,
       "releaseDate": "date",
       "title": "3:10 to Nowhere",

--- a/src/components/BioCarousel.jsx
+++ b/src/components/BioCarousel.jsx
@@ -10,8 +10,8 @@ export default function BioCarousel({ bios = [] }) {
   return (
     <div className="w-full overflow-x-auto touch-pan-x">
       <div className="flex space-x-4 p-4">
-        {bios.map((bio, index) => (
-          <Link key={index} to={`/meet/${index}`} className="block">
+        {bios.map((bio) => (
+          <Link key={bio.id} to={`/meet/${bio.id}`} className="block">
             <div
               className={[
                 "flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden",
@@ -19,7 +19,7 @@ export default function BioCarousel({ bios = [] }) {
               ].join(" ")}
               style={{ borderColor: "var(--border)" }}
             >
-              <motion.div layoutId={`bio-image-${index}`} className="w-full aspect-square">
+              <motion.div layoutId={`bio-image-${bio.id}`} className="w-full aspect-square">
                 <ImageWithFallback
                   src={bio.image}
                   alt={bio.name}

--- a/src/components/BioInfoPanel.jsx
+++ b/src/components/BioInfoPanel.jsx
@@ -31,7 +31,7 @@ export default function BioInfoPanel({ bio }) {
 
   return (
     <motion.div
-      key={bio.name}
+      key={bio.id}
       variants={containerVariants}
       initial="hidden"
       animate="show"

--- a/src/components/IssueCarousel.jsx
+++ b/src/components/IssueCarousel.jsx
@@ -11,13 +11,13 @@ export default function IssueCarousel({ issues = [] }) {
     <div className="w-full overflow-x-auto touch-pan-x">
       <div className="flex space-x-4 p-4">
         {issues.map((issue) => (
-          <Link key={issue.order} to={`/read/${issue.order}`} className="block">
+          <Link key={issue.id} to={`/read/${issue.id}`} className="block">
             <div
               className="flex-shrink-0 rounded border bg-[var(--background)] overflow-hidden w-[150px] sm:w-[200px] cursor-pointer"
               style={{ borderColor: "var(--border)" }}
             >
               <motion.div
-                layoutId={`issue-image-${issue.order}`}
+                layoutId={`issue-image-${issue.id}`}
                 className="w-full aspect-square"
               >
                 <ImageWithFallback

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -189,6 +189,7 @@ export default function Admin() {
     const joined = path.join('.');
     if (joined === 'issues') {
       return {
+        id: length + 1,
         order: length + 1,
         releaseDate: 'date',
         title: 'title',
@@ -203,6 +204,7 @@ export default function Admin() {
     }
     if (joined === 'bios') {
       return {
+        id: length + 1,
         name: 'Name',
         image: '/uploads/placeholder.png',
         biography: 'Biography',

--- a/src/pages/BioDetail.jsx
+++ b/src/pages/BioDetail.jsx
@@ -7,7 +7,7 @@ import content from "../../content/meet.json";
 
 export default function BioDetail() {
   const { bioId } = useParams();
-  const bio = content.bios?.[Number(bioId)];
+  const bio = content.bios?.find((b) => String(b.id) === bioId);
 
   if (!bio) {
     return (
@@ -18,11 +18,11 @@ export default function BioDetail() {
   }
 
   return (
-    <Panel id={`bio-${bioId}`} centerChildren={false}>
+    <Panel id={`bio-${bio.id}`} centerChildren={false}>
       <div className="flex flex-col">
         {bio.image && (
           <motion.div
-            layoutId={`bio-image-${bioId}`}
+            layoutId={`bio-image-${bio.id}`}
             className="w-full h-[50vh] overflow-hidden"
           >
             <ImageWithFallback

--- a/src/pages/IssueDetail.jsx
+++ b/src/pages/IssueDetail.jsx
@@ -7,7 +7,7 @@ import content from "../../content/read.json";
 
 export default function IssueDetail() {
   const { issueId } = useParams();
-  const issue = content.issues?.find((i) => String(i.order) === issueId);
+  const issue = content.issues?.find((i) => String(i.id) === issueId);
 
   if (!issue) {
     return (
@@ -22,7 +22,7 @@ export default function IssueDetail() {
       <div className="flex flex-col">
         {issue.heroImage && (
           <motion.div
-            layoutId={`issue-image-${issue.order}`}
+            layoutId={`issue-image-${issue.id}`}
             className="w-full h-[50vh] overflow-hidden"
           >
             <ImageWithFallback


### PR DESCRIPTION
## Summary
- add editable `id` fields to issue and bio content
- expose `id` in admin placeholders for new issues and bios
- reference issue and bio by `id` throughout carousels and detail pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78124d77883219d4184a2b8c75366