### PR TITLE
Synchronize panel and label hover animations

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -15,7 +15,7 @@ export default function PanelCard({
 }) {
   const content = (
     <motion.div
-      whileHover={{ scale: 1.02 }}
+      whileHover={{ scale: 1.02, transition: { duration: 0.3, ease: "easeOut" } }}
       initial={initial}
       animate={animate}
       transition={transition}
@@ -45,7 +45,7 @@ export default function PanelCard({
           <motion.span
             layoutId={`panel-label-${label}`}
             transition={{ duration: 0.4 }}
-            className="relative z-10 text-white transition-transform duration-700 ease-out group-hover:scale-105 font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
+            className="relative z-10 text-white transition-transform duration-300 ease-out group-hover:scale-105 font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}
           </motion.span>


### PR DESCRIPTION
## Summary
- Add explicit timing to panel hover scale transition
- Reduce label transition duration so hover animations run together

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c781b7df688321a9b738d57a8ac418