### PR TITLE
Add editable bio works with optional links

### DIFF
--- a/content/meet.json
+++ b/content/meet.json
@@ -22,7 +22,10 @@
       "name": "Name",
       "image": "/uploads/placeholder.png",
       "biography": "Biography",
-      "works": "Work 1, Work 2"
+      "works": [
+        { "text": "Work 1", "url": "" },
+        { "text": "Work 2", "url": "" }
+      ]
     }
   ]
 }

--- a/src/components/BioInfoPanel.jsx
+++ b/src/components/BioInfoPanel.jsx
@@ -23,11 +23,15 @@ export default function BioInfoPanel({ bio }) {
   }
 
   const works = Array.isArray(bio.works)
-    ? bio.works
+    ? bio.works.map((w) =>
+        typeof w === "string" ? { text: w, url: "" } : w
+      )
     : bio.works
+    ? bio.works
         .split(",")
-        .map((w) => w.trim())
-        .filter(Boolean);
+        .map((w) => ({ text: w.trim(), url: "" }))
+        .filter((w) => w.text)
+    : [];
 
   return (
     <motion.div
@@ -48,10 +52,23 @@ export default function BioInfoPanel({ bio }) {
       {works.length > 0 && (
         <motion.ul
           variants={itemVariants}
-          className="text-left text-gray-500 list-disc pl-5"
+          className="flex flex-wrap justify-center gap-4 list-none p-0 text-gray-500"
         >
           {works.map((work, idx) => (
-            <li key={idx}>{work}</li>
+            <li key={idx}>
+              {work.url ? (
+                <a
+                  href={work.url}
+                  className="no-underline hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {work.text}
+                </a>
+              ) : (
+                work.text
+              )}
+            </li>
           ))}
         </motion.ul>
       )}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -163,6 +163,13 @@ export default function Admin() {
                   {typeof item === "object"
                     ? renderFields(item, [...fieldPath, idx])
                     : renderInput(`${key}[${idx}]`, item, [...fieldPath, idx])}
+                  <button
+                    type="button"
+                    onClick={() => removeArrayItem([...fieldPath, idx])}
+                    className="mt-2 px-2 py-1 text-xs border rounded"
+                  >
+                    Remove
+                  </button>
                 </div>
               ))}
               <button
@@ -206,8 +213,11 @@ export default function Admin() {
         name: 'Name',
         image: '/uploads/placeholder.png',
         biography: 'Biography',
-        works: 'Work 1, Work 2',
+        works: [],
       };
+    }
+    if (path[path.length - 1] === 'works') {
+      return { text: 'Work', url: '' };
     }
     return '';
   };
@@ -220,6 +230,18 @@ export default function Admin() {
         arr = arr[path[i]];
       }
       arr.push(getPlaceholder(path, arr.length));
+      return updated;
+    });
+  };
+
+  const removeArrayItem = (path) => {
+    setFormData((prev) => {
+      const updated = structuredClone(prev);
+      let arr = updated;
+      for (let i = 0; i < path.length - 1; i += 1) {
+        arr = arr[path[i]];
+      }
+      arr.splice(path[path.length - 1], 1);
       return updated;
     });
   };


### PR DESCRIPTION
## Summary
- Display biography works horizontally with optional hidden-underline links
- Enable adding and removing individual works or entire bios in admin
- Store works as structured data with text and URL per item

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7821d64bc83219fd5cd1a37f3aed7