### PR TITLE
fix: align read page label transform

### DIFF
--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -16,7 +16,7 @@ export default function Read() {
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
           transition={{ duration: 0.4 }}
-          className={`${heading.className} ${heading.size} mb-2`}
+          className={`${heading.className} ${heading.size} mb-2 text-center`}
         >
           {heading.text}
         </motion.h1>


### PR DESCRIPTION
## Summary
- Center read page heading to align layout transform

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78236a40c83218511ccd3a3426d2e