### PR TITLE
feat: add hover scale to connect icons

### DIFF
--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -35,7 +35,7 @@ export default function Connect() {
               <a
                 key={icon.id}
                 href={icon.link || "#"}
-                className="w-24 h-24"
+                className="w-24 h-24 rounded-full overflow-hidden transition-transform duration-200 hover:scale-105"
               >
                 <img
                   src={icon.image}


### PR DESCRIPTION
## Summary
- subtly scale connect page icons on hover for visual feedback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c782e248f8832180ee62af45aeb1b3