### PR TITLE
Link issue credits to bio pages

### DIFF
--- a/content/meet.json
+++ b/content/meet.json
@@ -20,13 +20,24 @@
   "bios": [
     {
       "id": 1,
-      "name": "Name",
+      "name": "Jordan Johnson",
       "image": "/uploads/placeholder.png",
       "biography": "Biography",
-      "works": [
-        { "text": "Work 1", "url": "" },
-        { "text": "Work 2", "url": "" }
-      ]
+      "works": []
+    },
+    {
+      "id": 2,
+      "name": "Azrael Aguiar",
+      "image": "/uploads/placeholder.png",
+      "biography": "Biography",
+      "works": []
+    },
+    {
+      "id": 3,
+      "name": "Maja Opacic",
+      "image": "/uploads/placeholder.png",
+      "biography": "Biography",
+      "works": []
     }
   ]
 }

--- a/content/read.json
+++ b/content/read.json
@@ -25,9 +25,9 @@
       "title": "3:10 to Nowhere",
       "subtitle": "Time Waits for No Man",
       "description": "Abe Bone is stuck at a train station.",
-      "writer": "Jordan Johnson",
-      "artist": "Azrael Aguiar",
-      "colorist": "Maja Opacic",
+      "writer": { "text": "Jordan Johnson", "bioId": 1 },
+      "artist": { "text": "Azrael Aguiar", "bioId": 2 },
+      "colorist": { "text": "Maja Opacic", "bioId": 3 },
       "heroImage": "/uploads/placeholder.png",
       "thumbnail": "/uploads/placeholder.png"
     }

--- a/src/components/IssueInfoPanel.jsx
+++ b/src/components/IssueInfoPanel.jsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -24,6 +25,28 @@ export default function IssueInfoPanel({ issue }) {
 
   const title = issue.title?.rendered || issue.title;
 
+  const renderCredit = (credit, label) => {
+    if (!credit) return null;
+    const name =
+      typeof credit === "object" ? credit.text || credit.name : credit;
+    const bioId =
+      typeof credit === "object" ? credit.bioId || credit.id : null;
+
+    return (
+      <p>
+        {label}: {
+          bioId ? (
+            <Link to={`/meet/${bioId}`} className="no-underline hover:underline">
+              {name}
+            </Link>
+          ) : (
+            name
+          )
+        }
+      </p>
+    );
+  };
+
   return (
     <motion.div
       key={issue.id}
@@ -40,9 +63,9 @@ export default function IssueInfoPanel({ issue }) {
           variants={itemVariants}
           className="mt-2 text-sm text-gray-500 text-center"
         >
-          {issue.writer && <p>Writer: {issue.writer}</p>}
-          {issue.artist && <p>Artist: {issue.artist}</p>}
-          {issue.colorist && <p>Colorist: {issue.colorist}</p>}
+          {renderCredit(issue.writer, "Writer")}
+          {renderCredit(issue.artist, "Artist")}
+          {renderCredit(issue.colorist, "Colorist")}
         </motion.div>
       )}
       {issue.subtitle && (


### PR DESCRIPTION
## Summary
- Make issue writer, artist, and colorist credits link to their bio tiles when an id is provided
- Extend issue content to include bio ids for credits and add matching bios

## Testing
- `npm test` *(fails: npm not installed)*
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c78538ffc48321bc5ade158d311dc9