### PR TITLE
Use string IDs for issues and bios

### DIFF
--- a/content/meet.json
+++ b/content/meet.json
@@ -19,7 +19,7 @@
   },
   "bios": [
     {
-      "id": 1,
+      "id": "bio-1",
       "name": "Name",
       "image": "/uploads/placeholder.png",
       "biography": "Biography",

--- a/content/read.json
+++ b/content/read.json
@@ -19,7 +19,7 @@
   },
   "issues": [
     {
-      "id": 1,
+      "id": "issue-1",
       "order": 1,
       "releaseDate": "date",
       "title": "3:10 to Nowhere",

--- a/src/data/issues.js
+++ b/src/data/issues.js
@@ -1,6 +1,6 @@
 const issues = [
   {
-    id: 1,
+    id: 'issue-1',
     title: "Issue 1",
     subtitle: "The Beginning",
     previewImage: "https://via.placeholder.com/300x400?text=Issue+1+Preview",
@@ -12,7 +12,7 @@ const issues = [
     colorist: "The MEET",
   },
   {
-    id: 2,
+    id: 'issue-2',
     title: "Issue 2",
     subtitle: "The Sequel",
     previewImage: "https://via.placeholder.com/300x400?text=Issue+2+Preview",
@@ -24,7 +24,7 @@ const issues = [
     colorist: "The MEET",
   },
   {
-    id: 3,
+    id: 'issue-3',
     title: "Issue 3",
     subtitle: "The Finale",
     previewImage: "https://via.placeholder.com/300x400?text=Issue+3+Preview",

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -196,7 +196,7 @@ export default function Admin() {
     const joined = path.join('.');
     if (joined === 'issues') {
       return {
-        id: length + 1,
+        id: `issue-${length + 1}`,
         order: length + 1,
         releaseDate: 'date',
         title: 'title',
@@ -211,7 +211,7 @@ export default function Admin() {
     }
     if (joined === 'bios') {
       return {
-        id: length + 1,
+        id: `bio-${length + 1}`,
         name: 'Name',
         image: '/uploads/placeholder.png',
         biography: 'Biography',


### PR DESCRIPTION
## Summary
- Ensure placeholder generator in admin assigns text-based IDs like `issue-1` and `bio-1` for new items
- Convert existing issue and bio content to use string IDs
- Update static issue data to use string identifiers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78630b4488321a00ad8af4102b219