### PR TITLE
Handle panel morph for nested routes

### DIFF
--- a/src/components/PanelGrid.jsx
+++ b/src/components/PanelGrid.jsx
@@ -1,5 +1,5 @@
 import PanelCard from "./PanelCard";
-import { getPreviousPathname } from "../utils/navigation";
+import { getPreviousPathname, getFirstPathSegment } from "../utils/navigation";
 import read from "../../content/read.json";
 import buy from "../../content/buy.json";
 import meet from "../../content/meet.json";
@@ -33,8 +33,8 @@ const panels = [
 const TRANSFORM_DURATION = 0.4;
 
 export default function PanelGrid() {
-  const prevPath = getPreviousPathname();
-  const fromPanel = prevPath && prevPath !== "/" ? prevPath.slice(1).toUpperCase() : null;
+  const prevPath = getFirstPathSegment(getPreviousPathname());
+  const fromPanel = prevPath !== "/" ? prevPath.slice(1).toUpperCase() : null;
 
   return (
     <div className="h-full flex flex-col px-6 pt-10 pb-6">

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -3,3 +3,8 @@ export const updatePreviousPathname = (path) => {
   previousPathname = path;
 };
 export const getPreviousPathname = () => previousPathname;
+
+export const getFirstPathSegment = (path = "/") => {
+  const parts = path.split("/").filter(Boolean);
+  return parts.length ? `/${parts[0]}` : "/";
+};


### PR DESCRIPTION
## Summary
- add helper to extract first path segment
- use helper in PanelGrid to compute fromPanel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `node -e "import { getFirstPathSegment } from './src/utils/navigation.js'; console.log(getFirstPathSegment('/read/1'));"`

------
https://chatgpt.com/codex/tasks/task_e_68c78883886083218f89bcbba0b22709