### PR TITLE
Add bullet separators for works in bio tiles

### DIFF
--- a/src/components/BioInfoPanel.jsx
+++ b/src/components/BioInfoPanel.jsx
@@ -52,10 +52,11 @@ export default function BioInfoPanel({ bio }) {
       {works.length > 0 && (
         <motion.ul
           variants={itemVariants}
-          className="flex flex-wrap justify-center gap-4 list-none p-0 text-gray-500"
+          className="flex flex-wrap justify-center list-none p-0 text-gray-500"
         >
           {works.map((work, idx) => (
-            <li key={idx}>
+            <li key={idx} className="flex items-center">
+              {idx > 0 && <span className="mx-2">&bull;</span>}
               {work.url ? (
                 <a
                   href={work.url}


### PR DESCRIPTION
## Summary
- display works with bullet separators in BioInfoPanel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78a9d46588321b9b631cc38900cb8