### PR TITLE
feat: link issue credits to bios

### DIFF
--- a/content/meet.json
+++ b/content/meet.json
@@ -19,7 +19,7 @@
   },
   "bios": [
     {
-      "id": "bio-1",
+      "id": 1,
       "name": "Jordan Johnson",
       "image": "/uploads/placeholder.png",
       "biography": "Biography",

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD || "admin";
 const PAGES = [
@@ -36,6 +36,22 @@ export default function Admin() {
   const [defaultData, setDefaultData] = useState(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
+  const [bios, setBios] = useState([]);
+
+  useEffect(() => {
+    const loadBios = async () => {
+      try {
+        const res = await fetch('/api/pages/meet');
+        if (res.ok) {
+          const data = await res.json();
+          setBios(data.bios || []);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    loadBios();
+  }, []);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -202,9 +218,9 @@ export default function Admin() {
         title: 'title',
         subtitle: 'subtitle',
         description: 'description',
-        writer: 'writer',
-        artist: 'artist',
-        colorist: 'colorist',
+        writer: { text: 'Writer', bioId: '' },
+        artist: { text: 'Artist', bioId: '' },
+        colorist: { text: 'Colorist', bioId: '' },
         heroImage: '/uploads/placeholder.png',
         thumbnail: '/uploads/placeholder.png',
       };
@@ -269,6 +285,35 @@ export default function Admin() {
       }
       updateField(path, val);
     };
+
+    if (path[path.length - 1] === 'bioId') {
+      return (
+        <div key={name} className="flex flex-col gap-1">
+          <label className="font-medium">{displayLabel}</label>
+          <div className="flex items-center gap-2">
+            <select
+              value={String(value)}
+              onChange={handleChange}
+              className="border px-2 py-1 rounded"
+            >
+              <option value="">Select Bio</option>
+              {bios.map((bio) => (
+                <option key={bio.id} value={String(bio.id)}>
+                  {bio.name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => resetField(path)}
+              className="p-1 border rounded-full"
+            >
+              ↺
+            </button>
+          </div>
+        </div>
+      );
+    }
 
     if (typeof value === 'string') {
       const isDate = !Number.isNaN(Date.parse(value)) && /\d{4}-\d{2}-\d{2}/.test(value);


### PR DESCRIPTION
## Summary
- load bios in Admin dashboard so issue credits can reference bio tiles
- allow selecting a bio for writer, artist, and colorist when editing Read page issues
- normalize Meet page bio IDs for consistent linking

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78b1705bc8321aaeb181a3ae2d429