### PR TITLE
fix: update bio dropdown on change

### DIFF
--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -53,6 +53,12 @@ export default function Admin() {
     loadBios();
   }, []);
 
+  useEffect(() => {
+    if (selectedPage?.id === 'meet') {
+      setBios(formData?.bios || []);
+    }
+  }, [selectedPage, formData]);
+
   const handleSubmit = (e) => {
     e.preventDefault();
     if (password === ADMIN_PASSWORD) {


### PR DESCRIPTION
## Summary
- Keep admin bio dropdown in sync when bios are added or removed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78c745ce88321bfc245f1648d3653