### PR TITLE
Align panel labels with subpage headers

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -42,13 +42,13 @@ export default function PanelCard({
         className="absolute inset-0 border border-black rounded-lg flex items-center justify-center pointer-events-none"
       >
         {label && (
-          <motion.span
+          <motion.h1
             layoutId={`panel-label-${label}`}
             transition={{ duration: 0.4 }}
-            className="relative z-10 text-white transition-transform duration-300 ease-out group-hover:scale-105 font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
+            className="relative z-10 inline-block text-white transition-transform duration-300 ease-out group-hover:scale-105 font-bold uppercase text-center text-[clamp(3rem,8vw,10rem)]"
           >
             {label}
-          </motion.span>
+          </motion.h1>
         )}
       </motion.div>
     </motion.div>

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -14,7 +14,7 @@ export default function Buy() {
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
           transition={{ duration: 0.4 }}
-          className={`${heading.className} ${heading.size} mb-2`}
+          className={`inline-block ${heading.className} ${heading.size} text-center`}
         >
           {heading.text}
         </motion.h1>

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -27,7 +27,7 @@ export default function Connect() {
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
           transition={{ duration: 0.4 }}
-          className={`${heading.className} ${heading.size} mb-2`}
+          className={`inline-block ${heading.className} ${heading.size} text-center`}
         >
           {heading.text}
         </motion.h1>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -16,7 +16,7 @@ export default function Meet() {
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
           transition={{ duration: 0.4 }}
-          className={`${heading.className} ${heading.size} mb-2`}
+          className={`inline-block ${heading.className} ${heading.size} text-center`}
         >
           {heading.text}
         </motion.h1>

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -16,7 +16,7 @@ export default function Read() {
         <motion.h1
           layoutId={`panel-label-${panel.main.name}`}
           transition={{ duration: 0.4 }}
-          className={`${heading.className} ${heading.size} mb-2 text-center`}
+          className={`inline-block ${heading.className} ${heading.size} text-center`}
         >
           {heading.text}
         </motion.h1>


### PR DESCRIPTION
## Summary
- Use `motion.h1` for panel labels and match hero typography so transitions land cleanly on subpage headers.
- Normalize hero headings across subpages with inline-block layout and shared styles.

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c79211de7c8321a75aa42b8a171ece