### PR TITLE
Serve uploaded assets via Express and Vite proxy

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,8 +6,6 @@ import multer from 'multer';
 import { logRequest, logSuccess, logError } from './src/utils/logger.js';
 
 const app = express();
-app.use(cors());
-app.use(express.json());
 
 const CONTENT_DIR = path.join(process.cwd(), 'content');
 const UPLOAD_DIR = path.join(process.cwd(), 'public/uploads');
@@ -15,6 +13,10 @@ await fs.mkdir(CONTENT_DIR, { recursive: true });
 logSuccess('Content directory ready', { path: CONTENT_DIR });
 await fs.mkdir(UPLOAD_DIR, { recursive: true });
 logSuccess('Upload directory ready', { path: UPLOAD_DIR });
+
+app.use(cors());
+app.use(express.json());
+app.use('/uploads', express.static(UPLOAD_DIR));
 
 const PORT = process.env.PORT || 3001;
 const NODE_ENV = process.env.NODE_ENV || 'development';

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,11 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
+      '/uploads': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        secure: false,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- serve the uploads directory from Express so saved files are reachable
- add a Vite dev proxy for /uploads to forward requests to the backend

## Testing
- npm run lint
- npm run server
- npm run dev -- --host 0.0.0.0
- playwright admin upload verification script

------
https://chatgpt.com/codex/tasks/task_e_68c8c72978ac832199082e56d2ddce8e