### PR TITLE
Use shared panel label layout transitions with color blend

### DIFF
--- a/src/components/PanelCard.jsx
+++ b/src/components/PanelCard.jsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import ImageWithFallback from "./ImageWithFallback";
+import PanelLabel from "./PanelLabel";
 
 export default function PanelCard({
   className = "",
@@ -42,13 +43,12 @@ export default function PanelCard({
         className="absolute inset-0 border border-black rounded-lg flex items-center justify-center pointer-events-none"
       >
         {label && (
-          <motion.span
-            layoutId={`panel-label-${label}`}
-            transition={{ duration: 0.4 }}
+          <PanelLabel
+            id={label}
             className="relative z-10 text-white transition-transform duration-300 ease-out group-hover:scale-105 font-hero font-bold uppercase text-center text-[clamp(2rem,5vw,6rem)]"
           >
             {label}
-          </motion.span>
+          </PanelLabel>
         )}
       </motion.div>
     </motion.div>

--- a/src/components/PanelLabel.jsx
+++ b/src/components/PanelLabel.jsx
@@ -1,0 +1,37 @@
+import { motion } from "framer-motion";
+
+const DEFAULT_TRANSITION = {
+  layout: { duration: 0.4 },
+  duration: 0.4,
+};
+
+const motionElements = {
+  span: motion.span,
+  h1: motion.h1,
+  h2: motion.h2,
+  h3: motion.h3,
+  h4: motion.h4,
+  h5: motion.h5,
+  h6: motion.h6,
+  p: motion.p,
+  div: motion.div,
+};
+
+export default function PanelLabel({ id, as = "span", className = "", children, ...rest }) {
+  const MotionComponent = motionElements[as] || motion.span;
+  const layoutId = `panel-label-${String(id)}`;
+  const classes = ["transition-colors duration-500 ease-in-out", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <MotionComponent
+      layoutId={layoutId}
+      transition={DEFAULT_TRANSITION}
+      className={classes}
+      {...rest}
+    >
+      {children}
+    </MotionComponent>
+  );
+}

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -1,5 +1,5 @@
-import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import PanelLabel from "../components/PanelLabel";
 import content from "../../content/buy.json";
 
 export default function Buy() {
@@ -11,13 +11,13 @@ export default function Buy() {
   return (
     <Panel id={panel.main.name}>
       <div className="flex flex-col items-center">
-        <motion.h1
-          layoutId={`panel-label-${panel.main.name}`}
-          transition={{ duration: 0.4 }}
+        <PanelLabel
+          id={panel.main.name}
+          as="h1"
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}
-        </motion.h1>
+        </PanelLabel>
         {subtitle?.text && (
           <p className={`${subtitle.className} ${subtitle.size}`}>
             {subtitle.text}

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -1,6 +1,6 @@
-import { motion } from "framer-motion";
 import { useEffect } from "react";
 import Panel from "../components/Panel";
+import PanelLabel from "../components/PanelLabel";
 import content from "../../content/connect.json";
 
 export default function Connect() {
@@ -24,13 +24,13 @@ export default function Connect() {
   return (
     <Panel id={panel.main.name}>
       <div className="flex flex-col items-center">
-        <motion.h1
-          layoutId={`panel-label-${panel.main.name}`}
-          transition={{ duration: 0.4 }}
+        <PanelLabel
+          id={panel.main.name}
+          as="h1"
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}
-        </motion.h1>
+        </PanelLabel>
         {subtitle?.text && (
           <p className={`${subtitle.className} ${subtitle.size}`}>
             {subtitle.text}

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -1,5 +1,5 @@
-import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import PanelLabel from "../components/PanelLabel";
 import BioCarousel from "../components/BioCarousel";
 import content from "../../content/meet.json";
 
@@ -13,13 +13,13 @@ export default function Meet() {
   return (
     <Panel id={panel.main.name} centerChildren={false}>
       <div className="flex flex-col items-center">
-        <motion.h1
-          layoutId={`panel-label-${panel.main.name}`}
-          transition={{ duration: 0.4 }}
+        <PanelLabel
+          id={panel.main.name}
+          as="h1"
           className={`${heading.className} ${heading.size} mb-2`}
         >
           {heading.text}
-        </motion.h1>
+        </PanelLabel>
         {subtitle?.text && (
           <p className={`${subtitle.className} ${subtitle.size}`}>
             {subtitle.text}

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -1,5 +1,5 @@
-import { motion } from "framer-motion";
 import Panel from "../components/Panel";
+import PanelLabel from "../components/PanelLabel";
 import IssueCarousel from "../components/IssueCarousel";
 import content from "../../content/read.json";
 
@@ -13,13 +13,13 @@ export default function Read() {
   return (
     <Panel id={panel.main.name} centerChildren={false}>
       <div className="flex flex-col items-center w-full">
-        <motion.h1
-          layoutId={`panel-label-${panel.main.name}`}
-          transition={{ duration: 0.4 }}
+        <PanelLabel
+          id={panel.main.name}
+          as="h1"
           className={`${heading.className} ${heading.size} mb-2 text-center`}
         >
           {heading.text}
-        </motion.h1>
+        </PanelLabel>
         {subtitle?.text && (
           <p className={`${subtitle.className} ${subtitle.size}`}>
             {subtitle.text}


### PR DESCRIPTION
## Summary
- add a reusable `PanelLabel` motion component that shares layout IDs and applies a smooth color transition
- update panel cards and panel pages to use the new label component so text animates consistently between views

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8c823af388321b6efc77e57365a58