### PR TITLE
Tighten hero spacing on subpages

### DIFF
--- a/content/buy.json
+++ b/content/buy.json
@@ -13,7 +13,7 @@
     },
     "subtitle": {
       "text": "The best way to support Renowned is to back us on Kickstarter!",
-      "className": "mt-2 text-center font-sans",
+      "className": "mt-1 text-center font-sans",
       "size": "text-3xl"
     },
     "button": {

--- a/content/connect.json
+++ b/content/connect.json
@@ -13,7 +13,7 @@
     },
     "subtitle": {
       "text": "",
-      "className": "mt-2 text-center font-sans",
+      "className": "mt-1 text-center font-sans",
       "size": "text-8xl"
     }
   },

--- a/content/meet.json
+++ b/content/meet.json
@@ -13,7 +13,7 @@
     },
     "subtitle": {
       "text": "",
-      "className": "mt-2 text-center font-sans",
+      "className": "mt-1 text-center font-sans",
       "size": "text-8xl"
     }
   },

--- a/content/read.json
+++ b/content/read.json
@@ -13,7 +13,7 @@
     },
     "subtitle": {
       "text": "",
-      "className": "mt-2 text-center font-sans",
+      "className": "mt-1 text-center font-sans",
       "size": "text-8xl"
     }
   },

--- a/src/pages/Buy.jsx
+++ b/src/pages/Buy.jsx
@@ -14,7 +14,7 @@ export default function Buy() {
         <PanelLabel
           id={panel.main.name}
           as="h1"
-          className={`${heading.className} ${heading.size} mb-2`}
+          className={`${heading.className} ${heading.size} mb-1`}
         >
           {heading.text}
         </PanelLabel>

--- a/src/pages/Connect.jsx
+++ b/src/pages/Connect.jsx
@@ -27,7 +27,7 @@ export default function Connect() {
         <PanelLabel
           id={panel.main.name}
           as="h1"
-          className={`${heading.className} ${heading.size} mb-2`}
+          className={`${heading.className} ${heading.size} mb-1`}
         >
           {heading.text}
         </PanelLabel>

--- a/src/pages/Meet.jsx
+++ b/src/pages/Meet.jsx
@@ -16,7 +16,7 @@ export default function Meet() {
         <PanelLabel
           id={panel.main.name}
           as="h1"
-          className={`${heading.className} ${heading.size} mb-2`}
+          className={`${heading.className} ${heading.size} mb-1`}
         >
           {heading.text}
         </PanelLabel>

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -16,7 +16,7 @@ export default function Read() {
         <PanelLabel
           id={panel.main.name}
           as="h1"
-          className={`${heading.className} ${heading.size} mb-2 text-center`}
+          className={`${heading.className} ${heading.size} mb-1 text-center`}
         >
           {heading.text}
         </PanelLabel>


### PR DESCRIPTION
## Summary
- reduce PanelLabel bottom margin on Buy, Connect, Meet, and Read pages for tighter heading spacing
- decrease hero subtitle top margins in corresponding content JSON files to match the new layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8cdaf76d08321b3ded091b534d66f