### PR TITLE
Ensure read page scroll stays within grid

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,14 +23,8 @@ export default function App() {
   useEffect(() => {
     updatePreviousPathname(location.pathname);
   }, [location.pathname]);
-  const scrollLocked = location.pathname === "/";
-
   return (
-    <div
-      className={`fixed inset-0 p-3 bg-[#fdfaf5] ${
-        scrollLocked ? "overflow-hidden" : "overflow-y-auto"
-      }`}
-    >
+    <div className="fixed inset-0 p-3 bg-[#fdfaf5] overflow-hidden">
       <header className="absolute top-3 left-6 right-6 z-10 flex items-center justify-between">
         <Breadcrumbs />
         <AnimatePresence>

--- a/src/pages/Read.jsx
+++ b/src/pages/Read.jsx
@@ -12,20 +12,31 @@ export default function Read() {
 
   return (
     <Panel id={panel.main.name} centerChildren={false}>
-      <div className="flex flex-col items-center w-full">
-        <PanelLabel
-          id={panel.main.name}
-          as="h1"
-          className={`${heading.className} ${heading.size} mb-1 text-center`}
-        >
-          {heading.text}
-        </PanelLabel>
-        {subtitle?.text && (
-          <p className={`${subtitle.className} ${subtitle.size}`}>
-            {subtitle.text}
-          </p>
+      <div className="flex h-full w-full flex-col">
+        <div className="flex flex-col items-center text-center shrink-0">
+          <PanelLabel
+            id={panel.main.name}
+            as="h1"
+            className={`${heading.className} ${heading.size} mb-1 text-center`}
+          >
+            {heading.text}
+          </PanelLabel>
+          {subtitle?.text && (
+            <p className={`${subtitle.className} ${subtitle.size}`}>
+              {subtitle.text}
+            </p>
+          )}
+        </div>
+        {issues.length > 0 && (
+          <section
+            aria-label="Issue catalog"
+            className="mt-6 w-full flex-1 overflow-y-auto min-h-0"
+            role="region"
+            tabIndex={0}
+          >
+            <IssueCarousel issues={issues} />
+          </section>
         )}
-        {issues.length > 0 && <IssueCarousel issues={issues} />}
       </div>
     </Panel>
   );


### PR DESCRIPTION
## Summary
- ensure the root app wrapper always hides overflow so page width remains consistent across routes
- keep the read page header static and place the issues grid in a dedicated, focusable scroll region

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c979c97cec8321a499916244f7818b